### PR TITLE
Add SVG color-to-grayscale conversion pipeline with Streamlit UI

### DIFF
--- a/illustration-color-edit/.env.example
+++ b/illustration-color-edit/.env.example
@@ -1,0 +1,3 @@
+# No secrets required by default. Add here if integrations need keys later.
+# Example:
+# INKSCAPE_PATH=C:\Program Files\Inkscape\bin\inkscape.exe

--- a/illustration-color-edit/.gitignore
+++ b/illustration-color-edit/.gitignore
@@ -1,0 +1,29 @@
+# Secrets and local config
+.env
+config.json
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Virtual environment
+.venv/
+venv/
+
+# IDE
+.vscode/
+.idea/
+
+# Working directories
+tmp/*
+!tmp/.gitkeep
+output/
+
+# OS
+Thumbs.db
+.DS_Store

--- a/illustration-color-edit/README.md
+++ b/illustration-color-edit/README.md
@@ -32,7 +32,13 @@ ordering. This app lets you:
 ```
 illustration-color-edit/
 ├── app/
-│   └── app.py              # Streamlit entry point (thin scaffolding + tab routing)
+│   ├── app.py              # Streamlit entry point (scaffolding + tab routing)
+│   ├── common.py           # shared Streamlit helpers (swatches, badges, caching)
+│   ├── tab_library.py      # Library tab
+│   ├── tab_editor.py       # Editor tab (side-by-side preview, suggestions)
+│   ├── tab_global_map.py   # Global Map tab
+│   ├── tab_batch.py        # Batch Export tab
+│   └── tab_settings.py     # Settings tab
 ├── src/
 │   ├── svg_parser.py       # extract colors, parse <style> blocks, normalize
 │   ├── color_mapper.py     # exact + nearest-color matching, suggestion engine

--- a/illustration-color-edit/README.md
+++ b/illustration-color-edit/README.md
@@ -1,0 +1,212 @@
+# Illustration Color Edit
+
+Industrial-grade SVG color-to-grayscale conversion pipeline for book illustrations
+where color carries semantic meaning (red = bad, green = good, etc.).
+
+The tool consists of:
+
+- A **Streamlit app** (`app/app.py`) for interactive per-illustration mapping with
+  side-by-side preview and suggestion engine.
+- A **CLI batch processor** (`src/cli.py`) for converting an entire library once
+  mappings are locked in.
+
+Source illustrations are authored in Affinity Designer 2 (which has no scripting
+API), so the workflow is an SVG round-trip: export from Affinity → process here →
+re-open the processed SVG in Affinity.
+
+## Why this exists
+
+A typical book illustration in this project has 100+ colored data points. The
+print edition is grayscale, and color carries semantic weight (e.g. red = worse,
+green = better, yellow = warning). A naive RGB→luma conversion destroys that
+ordering. This app lets you:
+
+1. Define a **global** "this red always becomes this gray" mapping once.
+2. Reuse it across the whole book library.
+3. Override per illustration when needed.
+4. Preview side-by-side before committing.
+5. Batch-export the whole `input/` folder when mappings are final.
+
+## Project structure
+
+```
+illustration-color-edit/
+├── app/
+│   └── app.py              # Streamlit entry point (thin scaffolding + tab routing)
+├── src/
+│   ├── svg_parser.py       # extract colors, parse <style> blocks, normalize
+│   ├── color_mapper.py     # exact + nearest-color matching, suggestion engine
+│   ├── svg_writer.py       # apply mappings, write output SVG
+│   ├── library_manager.py  # scan input dir, track per-file status
+│   ├── mapping_store.py    # global + per-illustration mapping persistence
+│   ├── print_safety.py     # gray-value warnings for uncoated paper
+│   └── cli.py              # batch CLI entry point
+├── tests/                  # pytest unit tests
+├── tmp/                    # working scratch space (gitignored except .gitkeep)
+├── input/                  # source SVGs (Affinity exports)
+├── output/                 # converted SVGs (gitignored)
+├── metadata/               # per-illustration .mapping.json overrides + status
+├── config.json.example     # committed template
+├── config.json             # gitignored, real config
+├── .env.example
+├── .gitignore
+├── requirements.txt
+├── launch_app.bat
+└── README.md
+```
+
+## Setup (Windows + PowerShell)
+
+```powershell
+# from the project root
+python -m venv .venv
+& .\.venv\Scripts\python.exe -m pip install --upgrade pip
+& .\.venv\Scripts\python.exe -m pip install -r requirements.txt
+
+# create your real config from the template
+copy config.json.example config.json
+copy .env.example .env
+```
+
+## Setup (POSIX)
+
+```bash
+python -m venv .venv
+./.venv/bin/python -m pip install --upgrade pip
+./.venv/bin/python -m pip install -r requirements.txt
+
+cp config.json.example config.json
+cp .env.example .env
+```
+
+## Configuration
+
+`config.json` is the single source of truth for paths, color mappings, and
+matching parameters. Schema:
+
+```jsonc
+{
+  "global_color_map": {
+    "#E74C3C": { "target": "#333333", "label": "red / bad", "notes": "..." }
+  },
+  "matching": {
+    "nearest_enabled": true,
+    "metric": "lab",       // "lab" (CIE ΔE) or "rgb" (Euclidean)
+    "threshold": 10.0      // max distance before falling back to "manual"
+  },
+  "print_safety": {
+    "min_gray_value": "#EEEEEE",  // anything lighter triggers a warning
+    "warn_only": true             // set false to make CLI exit non-zero
+  },
+  "paths": {
+    "input_dir": "./input",
+    "output_dir": "./output",
+    "metadata_dir": "./metadata"
+  },
+  "logging": { "level": "INFO" }
+}
+```
+
+Hex codes are normalized to uppercase 6-digit `#RRGGBB` internally; you can
+write them in any case in the config.
+
+## Running the Streamlit app
+
+```powershell
+.\launch_app.bat
+```
+
+or
+
+```powershell
+& .\.venv\Scripts\python.exe -m streamlit run app\app.py
+```
+
+The app has five horizontal tabs:
+
+1. **Library** — list all SVGs in `input/` with status badges
+   (`pending` / `in_progress` / `reviewed` / `exported`). Click to open.
+2. **Editor** — side-by-side original vs. converted preview. Per-source-color
+   pickers with suggestions ("this red was previously mapped to #333333 in 4
+   other illustrations — reuse?"). Save / mark-reviewed.
+3. **Global Map** — view and edit the global registry. Shows usage counts.
+4. **Batch Export** — convert every reviewed (or every) illustration in `input/`
+   using current mappings. Progress + summary report.
+5. **Settings** — paths, matching threshold, print-safety threshold.
+
+## CLI batch usage
+
+```powershell
+& .\.venv\Scripts\python.exe -m src.cli --help
+
+# convert everything in input/ using current mappings
+& .\.venv\Scripts\python.exe -m src.cli convert
+
+# convert only illustrations marked reviewed
+& .\.venv\Scripts\python.exe -m src.cli convert --only-reviewed
+
+# inspect a single SVG without writing output
+& .\.venv\Scripts\python.exe -m src.cli inspect input\figure-01.svg
+
+# scan the library and print status
+& .\.venv\Scripts\python.exe -m src.cli status
+```
+
+The CLI prints a final report: files processed, files skipped, unmapped colors
+encountered (per file), and print-safety warnings.
+
+## End-to-end workflow
+
+1. Author the illustration in Affinity Designer 2 with the canonical color
+   palette (any reds you mean as "bad", any greens you mean as "good", etc.).
+2. **File → Export → SVG** into this project's `input/` folder.
+3. Open the Streamlit app, go to **Library**, click the new file.
+4. In **Editor**, review the auto-suggested mappings (exact-hex first, then
+   nearest within the configured threshold). Tweak any that look wrong using
+   the color picker. Watch the live side-by-side preview.
+5. **Save & mark reviewed.** The mapping is recorded in
+   `metadata/<file>.mapping.json` and any *new* exact mappings you confirmed
+   are also promoted to the global map.
+6. Repeat for the rest of the library.
+7. When everything is reviewed, run **Batch Export** (or `python -m src.cli
+   convert --only-reviewed`). Output SVGs land in `output/`.
+8. Re-open output SVGs in Affinity Designer 2 for any final touch-ups, then
+   place into the book layout.
+
+## Testing
+
+```powershell
+& .\.venv\Scripts\python.exe -m pytest
+```
+
+Unit tests cover `svg_parser`, `color_mapper`, and `mapping_store` — including
+the tricky cases: `<style>` blocks, named colors, `rgb(...)`, 3-digit
+shorthand, malformed input, and nearest-color edge cases.
+
+## SVG coverage
+
+The parser/writer round-trips:
+
+- `fill="#..."` and `stroke="#..."` inline attributes
+- `<stop stop-color="..."/>` and `stop-color` inside CSS
+- Hex colors inside `<style>` blocks (CSS rules)
+- `style="fill: ...; stroke: ..."` inline CSS
+- Named colors (`red`, `cornflowerblue`, ...) — normalized to hex
+- `rgb(r, g, b)` notation — normalized to hex
+- 3-digit shorthand (`#F00`) — expanded to `#FF0000`
+
+Everything else (paths, transforms, text, IDs, metadata, comments) is preserved
+byte-for-byte where possible so the round-trip back into Affinity is clean.
+
+## Optional Inkscape fallback
+
+If a particular SVG hits an edge case the parser doesn't handle cleanly (e.g.
+exotic CSS the in-house parser misses), pre-normalize it through Inkscape:
+
+```powershell
+& "C:\Program Files\Inkscape\bin\inkscape.exe" --export-plain-svg `
+    --export-filename=tmp\figure-01.normalized.svg input\figure-01.svg
+```
+
+then point the app at `tmp\figure-01.normalized.svg`. There's no automatic
+hand-off — Affinity Designer 2 itself produces clean SVG in practice.

--- a/illustration-color-edit/app/__init__.py
+++ b/illustration-color-edit/app/__init__.py
@@ -1,0 +1,1 @@
+"""Streamlit UI package — entry point in ``app.py``, one tab per ``tab_*.py``."""

--- a/illustration-color-edit/app/app.py
+++ b/illustration-color-edit/app/app.py
@@ -1,8 +1,9 @@
 """
 Streamlit entry point.
 
-Thin scaffolding only — five horizontal tabs (Library, Editor, Global Map,
-Batch Export, Settings) that delegate to ``src/`` modules for all logic.
+Scaffolding only — bootstraps config + session state, then routes the five
+horizontal tabs to ``app/tab_*.py``. All real logic lives in ``src/``;
+all per-tab UI lives in its own ``tab_*.py`` file.
 
 Run with::
 
@@ -18,39 +19,25 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-# Make ``src`` importable when streamlit launches us from elsewhere.
+# Make ``src`` and sibling tab modules importable when streamlit launches us.
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 import streamlit as st  # noqa: E402
 
-from src.color_mapper import (  # noqa: E402
-    ColorMapper,
-    MatchKind,
-    gray_value,
-    suggest_from_history,
-)
 from src.config import configure_logging, load_config  # noqa: E402
 from src.library_manager import LibraryManager  # noqa: E402
-from src.mapping_store import (  # noqa: E402
-    IllustrationMapping,
-    MappingStore,
-    VALID_STATUSES,
-    merge_mappings,
-)
-from src.print_safety import check_mapping  # noqa: E402
-from src.svg_parser import parse_svg  # noqa: E402
-from src.svg_writer import apply_mapping_with_report, write_converted_svg  # noqa: E402
+from src.mapping_store import MappingStore  # noqa: E402
+
+from app import tab_batch, tab_editor, tab_global_map, tab_library, tab_settings  # noqa: E402
 
 
 st.set_page_config(layout="wide", page_title="Illustration Color Edit")
 
 
-# --------------------------------------------------------------------------- #
-# Bootstrap config + state (once per session)
-# --------------------------------------------------------------------------- #
 def _bootstrap() -> None:
+    """Initialize config + persistent stores once per session."""
     if "config" in st.session_state:
         return
     cfg = load_config()
@@ -62,449 +49,13 @@ def _bootstrap() -> None:
     st.session_state.store = MappingStore(cfg_path, cfg.paths.metadata_dir)
     st.session_state.library = LibraryManager(cfg.paths.input_dir, st.session_state.store)
     st.session_state.current_file = None
-    st.session_state.editor_picks = {}        # source_hex -> manual target_hex (current illustration)
-    st.session_state.batch_report = None      # last batch run's summary
+    st.session_state.editor_picks = {}      # source_hex -> manual target_hex (current illustration)
+    st.session_state.batch_report = None    # last batch run's summary
 
 
 _bootstrap()
 
 
-# --------------------------------------------------------------------------- #
-# Caching wrappers (only cache pickleable returns)
-# --------------------------------------------------------------------------- #
-@st.cache_data(show_spinner=False)
-def cached_color_extract(path_str: str, mtime: float) -> dict[str, int]:
-    """Return ``{hex: usage_count}`` for an SVG, keyed by path + mtime."""
-    parsed = parse_svg(Path(path_str))
-    return {h: u.count for h, u in parsed.colors.items()}
-
-
-# --------------------------------------------------------------------------- #
-# Helpers
-# --------------------------------------------------------------------------- #
-def render_inline_svg(svg_bytes: bytes, *, height: int = 480) -> None:
-    """Render raw SVG bytes inline. Strips the XML decl so HTML doesn't choke."""
-    text = svg_bytes.decode("utf-8", errors="replace")
-    if text.lstrip().startswith("<?xml"):
-        text = text.split("?>", 1)[1].lstrip()
-    wrapper = (
-        f'<div style="background:#fff;border:1px solid #e0e0e0;border-radius:6px;'
-        f'padding:8px;height:{height}px;overflow:auto;display:flex;'
-        f'align-items:center;justify-content:center;">{text}</div>'
-    )
-    st.markdown(wrapper, unsafe_allow_html=True)
-
-
-def status_badge(status: str) -> str:
-    color = {
-        "pending": "#9CA3AF",
-        "in_progress": "#F59E0B",
-        "reviewed": "#10B981",
-        "exported": "#3B82F6",
-    }.get(status, "#9CA3AF")
-    return (
-        f'<span style="background:{color};color:#fff;padding:2px 8px;'
-        f'border-radius:10px;font-size:0.8em;">{status}</span>'
-    )
-
-
-def color_swatch(hex_color: str, size: int = 22) -> str:
-    return (
-        f'<span style="display:inline-block;width:{size}px;height:{size}px;'
-        f'background:{hex_color};border:1px solid #aaa;border-radius:3px;'
-        f'vertical-align:middle;"></span>'
-    )
-
-
-def fresh_mapper() -> ColorMapper:
-    """Build a ColorMapper from current config + live global map."""
-    cfg = st.session_state.config
-    store: MappingStore = st.session_state.store
-    return ColorMapper(global_map=store.load_global_map(), matching=cfg.matching)
-
-
-# --------------------------------------------------------------------------- #
-# Tab: Library
-# --------------------------------------------------------------------------- #
-def tab_library() -> None:
-    st.subheader("Library")
-    library: LibraryManager = st.session_state.library
-    cfg = st.session_state.config
-
-    cols = st.columns([3, 1, 1, 1])
-    cols[0].markdown(f"**Input directory:** `{cfg.paths.input_dir}`")
-    if cols[1].button("Rescan", key="lib_rescan", width="content"):
-        st.cache_data.clear()
-        st.rerun()
-    if cols[2].button("Open next pending", key="lib_open_next", width="content"):
-        nxt = library.next_pending()
-        if nxt:
-            st.session_state.current_file = nxt.filename
-            st.session_state.editor_picks = {}
-            st.success(f"Opened {nxt.filename}. Switch to the **Editor** tab.")
-        else:
-            st.info("No pending illustrations.")
-
-    entries = library.scan()
-    counts = library.status_counts()
-    cols[3].markdown(
-        f"<div style='line-height:1.6'>"
-        f"{status_badge('pending')} {counts['pending']} &nbsp;"
-        f"{status_badge('in_progress')} {counts['in_progress']} &nbsp;"
-        f"{status_badge('reviewed')} {counts['reviewed']} &nbsp;"
-        f"{status_badge('exported')} {counts['exported']}"
-        f"</div>",
-        unsafe_allow_html=True,
-    )
-
-    if not entries:
-        st.warning(f"No SVG files in {cfg.paths.input_dir}.")
-        return
-
-    # Header row
-    h = st.columns([3, 1, 1, 1, 1, 1])
-    for i, label in enumerate(["File", "Status", "Overrides", "Size (KB)", "Modified", "Open"]):
-        h[i].markdown(f"**{label}**")
-
-    for e in entries:
-        c = st.columns([3, 1, 1, 1, 1, 1])
-        c[0].write(e.filename)
-        c[1].markdown(status_badge(e.status), unsafe_allow_html=True)
-        c[2].write(e.override_count)
-        c[3].write(f"{e.size_kb:.1f}")
-        c[4].write(e.modified_iso[:19].replace("T", " ") if e.modified_iso else "—")
-        if c[5].button("Open", key=f"open_{e.filename}", width="content"):
-            st.session_state.current_file = e.filename
-            st.session_state.editor_picks = {}
-            st.toast(f"Opened {e.filename}. Switch to the **Editor** tab.")
-
-
-# --------------------------------------------------------------------------- #
-# Tab: Editor
-# --------------------------------------------------------------------------- #
-def tab_editor() -> None:
-    st.subheader("Editor")
-    library: LibraryManager = st.session_state.library
-    store: MappingStore = st.session_state.store
-    cfg = st.session_state.config
-
-    current = st.session_state.get("current_file")
-    if not current:
-        st.info("No illustration selected. Pick one in the **Library** tab.")
-        return
-
-    svg_path = cfg.paths.input_dir / current
-    if not svg_path.is_file():
-        st.error(f"{svg_path} no longer exists. Rescan in the Library tab.")
-        return
-
-    # Mark in_progress on first open if currently pending.
-    illu = store.load_illustration(current)
-    if illu.status == "pending":
-        illu.with_status("in_progress")
-        store.save_illustration(illu)
-
-    st.markdown(
-        f"**File:** `{current}` &nbsp; **Status:** {status_badge(illu.status)}",
-        unsafe_allow_html=True,
-    )
-
-    # Extract colors
-    mtime = svg_path.stat().st_mtime
-    colors = cached_color_extract(str(svg_path), mtime)
-    if not colors:
-        st.warning("No concrete colors found in this SVG (may be all `none`/`url(...)` references).")
-        return
-
-    mapper = fresh_mapper().with_overrides(illu.overrides)
-    history = store.history()
-
-    # Read existing picks: priority is editor_picks (in-progress edits)
-    # > saved overrides > suggestion.
-    picks: dict[str, str] = dict(st.session_state.editor_picks)
-
-    left, right = st.columns(2)
-    with left:
-        st.markdown("**Original**")
-        render_inline_svg(svg_path.read_bytes(), height=480)
-
-    # Build the live mapping from picks+overrides+global before rendering right pane
-    suggestions = {h: mapper.suggest(h) for h in sorted(colors)}
-    effective: dict[str, str] = {}
-    for src, sug in suggestions.items():
-        if src in picks:
-            effective[src] = picks[src]
-        elif src in illu.overrides:
-            effective[src] = illu.overrides[src]
-        elif sug.target is not None:
-            effective[src] = sug.target
-
-    full_mapping = merge_mappings(store.load_global_map(), effective)
-    converted_bytes, report = apply_mapping_with_report(svg_path, full_mapping)
-
-    with right:
-        st.markdown("**Converted (live preview)**")
-        render_inline_svg(converted_bytes, height=480)
-
-    st.divider()
-
-    # Color mapping panel
-    st.markdown(f"### Color mapping — {len(colors)} unique source colors")
-    safety_warnings = check_mapping(effective, cfg.print_safety)
-    safety_targets = {w.target for w in safety_warnings}
-
-    sorted_colors = sorted(colors.items(), key=lambda kv: -kv[1])  # most-used first
-    for src_hex, count in sorted_colors:
-        sug = suggestions[src_hex]
-        history_picks = suggest_from_history(src_hex, history)
-        with st.container(border=True):
-            row = st.columns([1, 2, 2, 3, 2])
-            row[0].markdown(
-                f"{color_swatch(src_hex)} <code>{src_hex}</code><br>"
-                f"<small>{count} uses</small>",
-                unsafe_allow_html=True,
-            )
-
-            # Suggestion summary
-            if sug.kind is MatchKind.EXACT:
-                badge = "<span style='color:#10B981'>● exact</span>"
-                detail = sug.label or ""
-            elif sug.kind is MatchKind.NEAR:
-                badge = "<span style='color:#F59E0B'>● near</span>"
-                detail = (
-                    f"via <code>{sug.via}</code> · "
-                    f"Δ{cfg.matching.metric.upper()}={sug.distance:.2f}"
-                )
-            else:
-                badge = "<span style='color:#EF4444'>● none</span>"
-                detail = "no exact or near match"
-            row[1].markdown(f"{badge}<br><small>{detail}</small>", unsafe_allow_html=True)
-
-            # Current picked target (initialized from suggestion / override)
-            initial = (
-                picks.get(src_hex)
-                or illu.overrides.get(src_hex)
-                or (sug.target if sug.target else "#888888")
-            )
-            picked = row[2].color_picker(
-                "target",
-                value=initial,
-                key=f"pick_{current}_{src_hex}",
-                label_visibility="collapsed",
-            ).upper()
-
-            # History suggestions (other illustrations)
-            if history_picks:
-                opts = [f"{t} ({c}x)" for t, c in history_picks[:5]]
-                chosen = row[3].selectbox(
-                    "history",
-                    options=["(keep current)"] + opts,
-                    key=f"hist_{current}_{src_hex}",
-                    label_visibility="collapsed",
-                )
-                if chosen != "(keep current)":
-                    chosen_hex = chosen.split(" ", 1)[0].upper()
-                    picked = chosen_hex
-            else:
-                row[3].markdown("<small>no history yet</small>", unsafe_allow_html=True)
-
-            # Print-safety hint for this row
-            if picked in safety_targets:
-                row[4].warning("⚠ light for print")
-            elif gray_value(picked) <= 16:
-                row[4].caption("very dark — OK")
-            else:
-                row[4].caption(f"luminance {gray_value(picked)}")
-
-            picks[src_hex] = picked
-
-    st.session_state.editor_picks = picks
-
-    # Action bar
-    st.divider()
-    a1, a2, a3, a4 = st.columns([1, 1, 1, 3])
-    if a1.button("Save (keep status)", key="ed_save", width="content"):
-        illu.overrides = {k.upper(): v.upper() for k, v in picks.items()}
-        store.save_illustration(illu)
-        st.success(f"Saved {len(illu.overrides)} overrides for {current}.")
-    if a2.button("Save & mark reviewed", key="ed_review", width="content", type="primary"):
-        illu.overrides = {k.upper(): v.upper() for k, v in picks.items()}
-        illu.with_status("reviewed")
-        store.save_illustration(illu)
-        # Promote new exact picks into the global map (only those that weren't there).
-        gm = store.load_global_map()
-        new_global = 0
-        for src, tgt in illu.overrides.items():
-            if src not in gm:
-                store.upsert_global_entry(src, tgt, label="auto-promoted from editor", notes="")
-                new_global += 1
-        st.success(
-            f"Saved & marked reviewed. {new_global} new entries promoted to the global map."
-        )
-    if a3.button("Promote ALL picks to global", key="ed_promote", width="content"):
-        for src, tgt in picks.items():
-            store.upsert_global_entry(src, tgt, label="manual promote", notes="")
-        st.success(f"Promoted {len(picks)} entries to the global map.")
-
-    if report.unmapped:
-        a4.warning(
-            f"{len(report.unmapped)} source colors are still unmapped: "
-            + ", ".join(sorted(report.unmapped)[:8])
-            + ("…" if len(report.unmapped) > 8 else "")
-        )
-
-
-# --------------------------------------------------------------------------- #
-# Tab: Global Map
-# --------------------------------------------------------------------------- #
-def tab_global_map() -> None:
-    st.subheader("Global color map")
-    store: MappingStore = st.session_state.store
-
-    gm = store.load_global_map()
-    usage = store.usage_counts()
-
-    if not gm:
-        st.info("Global map is empty. Map a few colors in the Editor first.")
-    else:
-        h = st.columns([1, 2, 1, 2, 3, 1])
-        for i, label in enumerate(["Source", "Target", "Used in", "Label", "Notes", ""]):
-            h[i].markdown(f"**{label}**")
-
-        for src in sorted(gm):
-            entry = gm[src]
-            c = st.columns([1, 2, 1, 2, 3, 1])
-            c[0].markdown(
-                f"{color_swatch(src)} <code>{src}</code>",
-                unsafe_allow_html=True,
-            )
-            new_target = c[1].color_picker(
-                "target", value=entry["target"], key=f"gm_t_{src}",
-                label_visibility="collapsed",
-            ).upper()
-            c[2].write(usage.get(src, 0))
-            new_label = c[3].text_input(
-                "label", value=entry.get("label", ""), key=f"gm_l_{src}",
-                label_visibility="collapsed",
-            )
-            new_notes = c[4].text_input(
-                "notes", value=entry.get("notes", ""), key=f"gm_n_{src}",
-                label_visibility="collapsed",
-            )
-            if c[5].button("✕", key=f"gm_del_{src}", help="Remove entry"):
-                store.remove_global_entry(src)
-                st.rerun()
-
-            # Persist on change.
-            if (
-                new_target != entry["target"]
-                or new_label != entry.get("label", "")
-                or new_notes != entry.get("notes", "")
-            ):
-                store.upsert_global_entry(src, new_target, label=new_label, notes=new_notes)
-
-    st.divider()
-    st.markdown("**Add a new entry**")
-    with st.form("add_global", clear_on_submit=True):
-        f = st.columns([1, 1, 2, 3, 1])
-        nsrc = f[0].text_input("source hex", value="#")
-        ntgt = f[1].color_picker("target", value="#888888")
-        nlbl = f[2].text_input("label")
-        nnts = f[3].text_input("notes")
-        if f[4].form_submit_button("Add"):
-            if not nsrc.startswith("#") or len(nsrc) != 7:
-                st.error("Source must be #RRGGBB.")
-            else:
-                store.upsert_global_entry(nsrc.upper(), ntgt.upper(), label=nlbl, notes=nnts)
-                st.success(f"Added {nsrc.upper()} → {ntgt.upper()}.")
-
-
-# --------------------------------------------------------------------------- #
-# Tab: Batch Export
-# --------------------------------------------------------------------------- #
-def tab_batch() -> None:
-    st.subheader("Batch export")
-    library: LibraryManager = st.session_state.library
-    store: MappingStore = st.session_state.store
-    cfg = st.session_state.config
-
-    only_reviewed = st.checkbox("Only export reviewed illustrations", value=True, key="batch_reviewed")
-    st.markdown(f"**Output directory:** `{cfg.paths.output_dir}`")
-
-    entries = library.scan()
-    if only_reviewed:
-        entries = [e for e in entries if e.status == "reviewed"]
-
-    st.write(f"{len(entries)} illustration(s) queued.")
-
-    if st.button("Run batch export", type="primary", key="batch_run", width="content"):
-        if not entries:
-            st.warning("Nothing to export.")
-        else:
-            cfg.paths.output_dir.mkdir(parents=True, exist_ok=True)
-            global_map = store.load_global_map()
-            log_rows: list[dict] = []
-            progress = st.progress(0.0)
-            for i, e in enumerate(entries, start=1):
-                illu = store.load_illustration(e.filename)
-                merged = merge_mappings(global_map, illu.overrides)
-                dst = cfg.paths.output_dir / e.filename
-                report = write_converted_svg(e.path, merged, dst)
-                # Mark exported
-                illu.with_status("exported")
-                store.save_illustration(illu)
-                log_rows.append({
-                    "file": e.filename,
-                    "replacements": report.replacements,
-                    "unmapped_colors": len(report.unmapped),
-                    "unmapped_list": ", ".join(sorted(report.unmapped)[:8]),
-                })
-                progress.progress(i / len(entries))
-            st.session_state.batch_report = log_rows
-            st.success(f"Exported {len(entries)} files to {cfg.paths.output_dir}.")
-
-    rows = st.session_state.get("batch_report")
-    if rows:
-        st.markdown("### Last run report")
-        st.dataframe(rows, width="stretch")
-
-
-# --------------------------------------------------------------------------- #
-# Tab: Settings
-# --------------------------------------------------------------------------- #
-def tab_settings() -> None:
-    st.subheader("Settings")
-    cfg = st.session_state.config
-    st.caption(f"Config file: `{cfg.source_path}`")
-
-    st.markdown("### Paths")
-    st.write({
-        "input_dir": str(cfg.paths.input_dir),
-        "output_dir": str(cfg.paths.output_dir),
-        "metadata_dir": str(cfg.paths.metadata_dir),
-    })
-    st.caption("Edit `config.json` directly to change paths, then restart the app.")
-
-    st.markdown("### Matching")
-    st.write({
-        "nearest_enabled": cfg.matching.nearest_enabled,
-        "metric": cfg.matching.metric,
-        "threshold": cfg.matching.threshold,
-    })
-
-    st.markdown("### Print safety")
-    st.write({
-        "min_gray_value": cfg.print_safety.min_gray_value,
-        "warn_only": cfg.print_safety.warn_only,
-    })
-
-    st.markdown("### Logging")
-    st.write({"level": cfg.log_level})
-
-
-# --------------------------------------------------------------------------- #
-# Top-level layout
-# --------------------------------------------------------------------------- #
 st.title("Illustration Color Edit")
 st.caption("SVG → grayscale conversion pipeline for the book project.")
 
@@ -512,12 +63,12 @@ t_lib, t_edit, t_global, t_batch, t_settings = st.tabs(
     ["Library", "Editor", "Global Map", "Batch Export", "Settings"]
 )
 with t_lib:
-    tab_library()
+    tab_library.render()
 with t_edit:
-    tab_editor()
+    tab_editor.render()
 with t_global:
-    tab_global_map()
+    tab_global_map.render()
 with t_batch:
-    tab_batch()
+    tab_batch.render()
 with t_settings:
-    tab_settings()
+    tab_settings.render()

--- a/illustration-color-edit/app/app.py
+++ b/illustration-color-edit/app/app.py
@@ -1,0 +1,523 @@
+"""
+Streamlit entry point.
+
+Thin scaffolding only — five horizontal tabs (Library, Editor, Global Map,
+Batch Export, Settings) that delegate to ``src/`` modules for all logic.
+
+Run with::
+
+    streamlit run app/app.py
+
+or via the Windows wrapper::
+
+    launch_app.bat
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make ``src`` importable when streamlit launches us from elsewhere.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import streamlit as st  # noqa: E402
+
+from src.color_mapper import (  # noqa: E402
+    ColorMapper,
+    MatchKind,
+    gray_value,
+    suggest_from_history,
+)
+from src.config import configure_logging, load_config  # noqa: E402
+from src.library_manager import LibraryManager  # noqa: E402
+from src.mapping_store import (  # noqa: E402
+    IllustrationMapping,
+    MappingStore,
+    VALID_STATUSES,
+    merge_mappings,
+)
+from src.print_safety import check_mapping  # noqa: E402
+from src.svg_parser import parse_svg  # noqa: E402
+from src.svg_writer import apply_mapping_with_report, write_converted_svg  # noqa: E402
+
+
+st.set_page_config(layout="wide", page_title="Illustration Color Edit")
+
+
+# --------------------------------------------------------------------------- #
+# Bootstrap config + state (once per session)
+# --------------------------------------------------------------------------- #
+def _bootstrap() -> None:
+    if "config" in st.session_state:
+        return
+    cfg = load_config()
+    cfg.ensure_dirs()
+    configure_logging(cfg.log_level)
+
+    cfg_path = cfg.source_path or (_PROJECT_ROOT / "config.json")
+    st.session_state.config = cfg
+    st.session_state.store = MappingStore(cfg_path, cfg.paths.metadata_dir)
+    st.session_state.library = LibraryManager(cfg.paths.input_dir, st.session_state.store)
+    st.session_state.current_file = None
+    st.session_state.editor_picks = {}        # source_hex -> manual target_hex (current illustration)
+    st.session_state.batch_report = None      # last batch run's summary
+
+
+_bootstrap()
+
+
+# --------------------------------------------------------------------------- #
+# Caching wrappers (only cache pickleable returns)
+# --------------------------------------------------------------------------- #
+@st.cache_data(show_spinner=False)
+def cached_color_extract(path_str: str, mtime: float) -> dict[str, int]:
+    """Return ``{hex: usage_count}`` for an SVG, keyed by path + mtime."""
+    parsed = parse_svg(Path(path_str))
+    return {h: u.count for h, u in parsed.colors.items()}
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def render_inline_svg(svg_bytes: bytes, *, height: int = 480) -> None:
+    """Render raw SVG bytes inline. Strips the XML decl so HTML doesn't choke."""
+    text = svg_bytes.decode("utf-8", errors="replace")
+    if text.lstrip().startswith("<?xml"):
+        text = text.split("?>", 1)[1].lstrip()
+    wrapper = (
+        f'<div style="background:#fff;border:1px solid #e0e0e0;border-radius:6px;'
+        f'padding:8px;height:{height}px;overflow:auto;display:flex;'
+        f'align-items:center;justify-content:center;">{text}</div>'
+    )
+    st.markdown(wrapper, unsafe_allow_html=True)
+
+
+def status_badge(status: str) -> str:
+    color = {
+        "pending": "#9CA3AF",
+        "in_progress": "#F59E0B",
+        "reviewed": "#10B981",
+        "exported": "#3B82F6",
+    }.get(status, "#9CA3AF")
+    return (
+        f'<span style="background:{color};color:#fff;padding:2px 8px;'
+        f'border-radius:10px;font-size:0.8em;">{status}</span>'
+    )
+
+
+def color_swatch(hex_color: str, size: int = 22) -> str:
+    return (
+        f'<span style="display:inline-block;width:{size}px;height:{size}px;'
+        f'background:{hex_color};border:1px solid #aaa;border-radius:3px;'
+        f'vertical-align:middle;"></span>'
+    )
+
+
+def fresh_mapper() -> ColorMapper:
+    """Build a ColorMapper from current config + live global map."""
+    cfg = st.session_state.config
+    store: MappingStore = st.session_state.store
+    return ColorMapper(global_map=store.load_global_map(), matching=cfg.matching)
+
+
+# --------------------------------------------------------------------------- #
+# Tab: Library
+# --------------------------------------------------------------------------- #
+def tab_library() -> None:
+    st.subheader("Library")
+    library: LibraryManager = st.session_state.library
+    cfg = st.session_state.config
+
+    cols = st.columns([3, 1, 1, 1])
+    cols[0].markdown(f"**Input directory:** `{cfg.paths.input_dir}`")
+    if cols[1].button("Rescan", key="lib_rescan", width="content"):
+        st.cache_data.clear()
+        st.rerun()
+    if cols[2].button("Open next pending", key="lib_open_next", width="content"):
+        nxt = library.next_pending()
+        if nxt:
+            st.session_state.current_file = nxt.filename
+            st.session_state.editor_picks = {}
+            st.success(f"Opened {nxt.filename}. Switch to the **Editor** tab.")
+        else:
+            st.info("No pending illustrations.")
+
+    entries = library.scan()
+    counts = library.status_counts()
+    cols[3].markdown(
+        f"<div style='line-height:1.6'>"
+        f"{status_badge('pending')} {counts['pending']} &nbsp;"
+        f"{status_badge('in_progress')} {counts['in_progress']} &nbsp;"
+        f"{status_badge('reviewed')} {counts['reviewed']} &nbsp;"
+        f"{status_badge('exported')} {counts['exported']}"
+        f"</div>",
+        unsafe_allow_html=True,
+    )
+
+    if not entries:
+        st.warning(f"No SVG files in {cfg.paths.input_dir}.")
+        return
+
+    # Header row
+    h = st.columns([3, 1, 1, 1, 1, 1])
+    for i, label in enumerate(["File", "Status", "Overrides", "Size (KB)", "Modified", "Open"]):
+        h[i].markdown(f"**{label}**")
+
+    for e in entries:
+        c = st.columns([3, 1, 1, 1, 1, 1])
+        c[0].write(e.filename)
+        c[1].markdown(status_badge(e.status), unsafe_allow_html=True)
+        c[2].write(e.override_count)
+        c[3].write(f"{e.size_kb:.1f}")
+        c[4].write(e.modified_iso[:19].replace("T", " ") if e.modified_iso else "—")
+        if c[5].button("Open", key=f"open_{e.filename}", width="content"):
+            st.session_state.current_file = e.filename
+            st.session_state.editor_picks = {}
+            st.toast(f"Opened {e.filename}. Switch to the **Editor** tab.")
+
+
+# --------------------------------------------------------------------------- #
+# Tab: Editor
+# --------------------------------------------------------------------------- #
+def tab_editor() -> None:
+    st.subheader("Editor")
+    library: LibraryManager = st.session_state.library
+    store: MappingStore = st.session_state.store
+    cfg = st.session_state.config
+
+    current = st.session_state.get("current_file")
+    if not current:
+        st.info("No illustration selected. Pick one in the **Library** tab.")
+        return
+
+    svg_path = cfg.paths.input_dir / current
+    if not svg_path.is_file():
+        st.error(f"{svg_path} no longer exists. Rescan in the Library tab.")
+        return
+
+    # Mark in_progress on first open if currently pending.
+    illu = store.load_illustration(current)
+    if illu.status == "pending":
+        illu.with_status("in_progress")
+        store.save_illustration(illu)
+
+    st.markdown(
+        f"**File:** `{current}` &nbsp; **Status:** {status_badge(illu.status)}",
+        unsafe_allow_html=True,
+    )
+
+    # Extract colors
+    mtime = svg_path.stat().st_mtime
+    colors = cached_color_extract(str(svg_path), mtime)
+    if not colors:
+        st.warning("No concrete colors found in this SVG (may be all `none`/`url(...)` references).")
+        return
+
+    mapper = fresh_mapper().with_overrides(illu.overrides)
+    history = store.history()
+
+    # Read existing picks: priority is editor_picks (in-progress edits)
+    # > saved overrides > suggestion.
+    picks: dict[str, str] = dict(st.session_state.editor_picks)
+
+    left, right = st.columns(2)
+    with left:
+        st.markdown("**Original**")
+        render_inline_svg(svg_path.read_bytes(), height=480)
+
+    # Build the live mapping from picks+overrides+global before rendering right pane
+    suggestions = {h: mapper.suggest(h) for h in sorted(colors)}
+    effective: dict[str, str] = {}
+    for src, sug in suggestions.items():
+        if src in picks:
+            effective[src] = picks[src]
+        elif src in illu.overrides:
+            effective[src] = illu.overrides[src]
+        elif sug.target is not None:
+            effective[src] = sug.target
+
+    full_mapping = merge_mappings(store.load_global_map(), effective)
+    converted_bytes, report = apply_mapping_with_report(svg_path, full_mapping)
+
+    with right:
+        st.markdown("**Converted (live preview)**")
+        render_inline_svg(converted_bytes, height=480)
+
+    st.divider()
+
+    # Color mapping panel
+    st.markdown(f"### Color mapping — {len(colors)} unique source colors")
+    safety_warnings = check_mapping(effective, cfg.print_safety)
+    safety_targets = {w.target for w in safety_warnings}
+
+    sorted_colors = sorted(colors.items(), key=lambda kv: -kv[1])  # most-used first
+    for src_hex, count in sorted_colors:
+        sug = suggestions[src_hex]
+        history_picks = suggest_from_history(src_hex, history)
+        with st.container(border=True):
+            row = st.columns([1, 2, 2, 3, 2])
+            row[0].markdown(
+                f"{color_swatch(src_hex)} <code>{src_hex}</code><br>"
+                f"<small>{count} uses</small>",
+                unsafe_allow_html=True,
+            )
+
+            # Suggestion summary
+            if sug.kind is MatchKind.EXACT:
+                badge = "<span style='color:#10B981'>● exact</span>"
+                detail = sug.label or ""
+            elif sug.kind is MatchKind.NEAR:
+                badge = "<span style='color:#F59E0B'>● near</span>"
+                detail = (
+                    f"via <code>{sug.via}</code> · "
+                    f"Δ{cfg.matching.metric.upper()}={sug.distance:.2f}"
+                )
+            else:
+                badge = "<span style='color:#EF4444'>● none</span>"
+                detail = "no exact or near match"
+            row[1].markdown(f"{badge}<br><small>{detail}</small>", unsafe_allow_html=True)
+
+            # Current picked target (initialized from suggestion / override)
+            initial = (
+                picks.get(src_hex)
+                or illu.overrides.get(src_hex)
+                or (sug.target if sug.target else "#888888")
+            )
+            picked = row[2].color_picker(
+                "target",
+                value=initial,
+                key=f"pick_{current}_{src_hex}",
+                label_visibility="collapsed",
+            ).upper()
+
+            # History suggestions (other illustrations)
+            if history_picks:
+                opts = [f"{t} ({c}x)" for t, c in history_picks[:5]]
+                chosen = row[3].selectbox(
+                    "history",
+                    options=["(keep current)"] + opts,
+                    key=f"hist_{current}_{src_hex}",
+                    label_visibility="collapsed",
+                )
+                if chosen != "(keep current)":
+                    chosen_hex = chosen.split(" ", 1)[0].upper()
+                    picked = chosen_hex
+            else:
+                row[3].markdown("<small>no history yet</small>", unsafe_allow_html=True)
+
+            # Print-safety hint for this row
+            if picked in safety_targets:
+                row[4].warning("⚠ light for print")
+            elif gray_value(picked) <= 16:
+                row[4].caption("very dark — OK")
+            else:
+                row[4].caption(f"luminance {gray_value(picked)}")
+
+            picks[src_hex] = picked
+
+    st.session_state.editor_picks = picks
+
+    # Action bar
+    st.divider()
+    a1, a2, a3, a4 = st.columns([1, 1, 1, 3])
+    if a1.button("Save (keep status)", key="ed_save", width="content"):
+        illu.overrides = {k.upper(): v.upper() for k, v in picks.items()}
+        store.save_illustration(illu)
+        st.success(f"Saved {len(illu.overrides)} overrides for {current}.")
+    if a2.button("Save & mark reviewed", key="ed_review", width="content", type="primary"):
+        illu.overrides = {k.upper(): v.upper() for k, v in picks.items()}
+        illu.with_status("reviewed")
+        store.save_illustration(illu)
+        # Promote new exact picks into the global map (only those that weren't there).
+        gm = store.load_global_map()
+        new_global = 0
+        for src, tgt in illu.overrides.items():
+            if src not in gm:
+                store.upsert_global_entry(src, tgt, label="auto-promoted from editor", notes="")
+                new_global += 1
+        st.success(
+            f"Saved & marked reviewed. {new_global} new entries promoted to the global map."
+        )
+    if a3.button("Promote ALL picks to global", key="ed_promote", width="content"):
+        for src, tgt in picks.items():
+            store.upsert_global_entry(src, tgt, label="manual promote", notes="")
+        st.success(f"Promoted {len(picks)} entries to the global map.")
+
+    if report.unmapped:
+        a4.warning(
+            f"{len(report.unmapped)} source colors are still unmapped: "
+            + ", ".join(sorted(report.unmapped)[:8])
+            + ("…" if len(report.unmapped) > 8 else "")
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Tab: Global Map
+# --------------------------------------------------------------------------- #
+def tab_global_map() -> None:
+    st.subheader("Global color map")
+    store: MappingStore = st.session_state.store
+
+    gm = store.load_global_map()
+    usage = store.usage_counts()
+
+    if not gm:
+        st.info("Global map is empty. Map a few colors in the Editor first.")
+    else:
+        h = st.columns([1, 2, 1, 2, 3, 1])
+        for i, label in enumerate(["Source", "Target", "Used in", "Label", "Notes", ""]):
+            h[i].markdown(f"**{label}**")
+
+        for src in sorted(gm):
+            entry = gm[src]
+            c = st.columns([1, 2, 1, 2, 3, 1])
+            c[0].markdown(
+                f"{color_swatch(src)} <code>{src}</code>",
+                unsafe_allow_html=True,
+            )
+            new_target = c[1].color_picker(
+                "target", value=entry["target"], key=f"gm_t_{src}",
+                label_visibility="collapsed",
+            ).upper()
+            c[2].write(usage.get(src, 0))
+            new_label = c[3].text_input(
+                "label", value=entry.get("label", ""), key=f"gm_l_{src}",
+                label_visibility="collapsed",
+            )
+            new_notes = c[4].text_input(
+                "notes", value=entry.get("notes", ""), key=f"gm_n_{src}",
+                label_visibility="collapsed",
+            )
+            if c[5].button("✕", key=f"gm_del_{src}", help="Remove entry"):
+                store.remove_global_entry(src)
+                st.rerun()
+
+            # Persist on change.
+            if (
+                new_target != entry["target"]
+                or new_label != entry.get("label", "")
+                or new_notes != entry.get("notes", "")
+            ):
+                store.upsert_global_entry(src, new_target, label=new_label, notes=new_notes)
+
+    st.divider()
+    st.markdown("**Add a new entry**")
+    with st.form("add_global", clear_on_submit=True):
+        f = st.columns([1, 1, 2, 3, 1])
+        nsrc = f[0].text_input("source hex", value="#")
+        ntgt = f[1].color_picker("target", value="#888888")
+        nlbl = f[2].text_input("label")
+        nnts = f[3].text_input("notes")
+        if f[4].form_submit_button("Add"):
+            if not nsrc.startswith("#") or len(nsrc) != 7:
+                st.error("Source must be #RRGGBB.")
+            else:
+                store.upsert_global_entry(nsrc.upper(), ntgt.upper(), label=nlbl, notes=nnts)
+                st.success(f"Added {nsrc.upper()} → {ntgt.upper()}.")
+
+
+# --------------------------------------------------------------------------- #
+# Tab: Batch Export
+# --------------------------------------------------------------------------- #
+def tab_batch() -> None:
+    st.subheader("Batch export")
+    library: LibraryManager = st.session_state.library
+    store: MappingStore = st.session_state.store
+    cfg = st.session_state.config
+
+    only_reviewed = st.checkbox("Only export reviewed illustrations", value=True, key="batch_reviewed")
+    st.markdown(f"**Output directory:** `{cfg.paths.output_dir}`")
+
+    entries = library.scan()
+    if only_reviewed:
+        entries = [e for e in entries if e.status == "reviewed"]
+
+    st.write(f"{len(entries)} illustration(s) queued.")
+
+    if st.button("Run batch export", type="primary", key="batch_run", width="content"):
+        if not entries:
+            st.warning("Nothing to export.")
+        else:
+            cfg.paths.output_dir.mkdir(parents=True, exist_ok=True)
+            global_map = store.load_global_map()
+            log_rows: list[dict] = []
+            progress = st.progress(0.0)
+            for i, e in enumerate(entries, start=1):
+                illu = store.load_illustration(e.filename)
+                merged = merge_mappings(global_map, illu.overrides)
+                dst = cfg.paths.output_dir / e.filename
+                report = write_converted_svg(e.path, merged, dst)
+                # Mark exported
+                illu.with_status("exported")
+                store.save_illustration(illu)
+                log_rows.append({
+                    "file": e.filename,
+                    "replacements": report.replacements,
+                    "unmapped_colors": len(report.unmapped),
+                    "unmapped_list": ", ".join(sorted(report.unmapped)[:8]),
+                })
+                progress.progress(i / len(entries))
+            st.session_state.batch_report = log_rows
+            st.success(f"Exported {len(entries)} files to {cfg.paths.output_dir}.")
+
+    rows = st.session_state.get("batch_report")
+    if rows:
+        st.markdown("### Last run report")
+        st.dataframe(rows, width="stretch")
+
+
+# --------------------------------------------------------------------------- #
+# Tab: Settings
+# --------------------------------------------------------------------------- #
+def tab_settings() -> None:
+    st.subheader("Settings")
+    cfg = st.session_state.config
+    st.caption(f"Config file: `{cfg.source_path}`")
+
+    st.markdown("### Paths")
+    st.write({
+        "input_dir": str(cfg.paths.input_dir),
+        "output_dir": str(cfg.paths.output_dir),
+        "metadata_dir": str(cfg.paths.metadata_dir),
+    })
+    st.caption("Edit `config.json` directly to change paths, then restart the app.")
+
+    st.markdown("### Matching")
+    st.write({
+        "nearest_enabled": cfg.matching.nearest_enabled,
+        "metric": cfg.matching.metric,
+        "threshold": cfg.matching.threshold,
+    })
+
+    st.markdown("### Print safety")
+    st.write({
+        "min_gray_value": cfg.print_safety.min_gray_value,
+        "warn_only": cfg.print_safety.warn_only,
+    })
+
+    st.markdown("### Logging")
+    st.write({"level": cfg.log_level})
+
+
+# --------------------------------------------------------------------------- #
+# Top-level layout
+# --------------------------------------------------------------------------- #
+st.title("Illustration Color Edit")
+st.caption("SVG → grayscale conversion pipeline for the book project.")
+
+t_lib, t_edit, t_global, t_batch, t_settings = st.tabs(
+    ["Library", "Editor", "Global Map", "Batch Export", "Settings"]
+)
+with t_lib:
+    tab_library()
+with t_edit:
+    tab_editor()
+with t_global:
+    tab_global_map()
+with t_batch:
+    tab_batch()
+with t_settings:
+    tab_settings()

--- a/illustration-color-edit/app/common.py
+++ b/illustration-color-edit/app/common.py
@@ -1,0 +1,73 @@
+"""
+Shared UI helpers for the Streamlit tabs.
+
+Anything that's *Streamlit-specific* but reused across more than one tab
+lives here. Pure data logic stays in ``src/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import streamlit as st
+
+from src.color_mapper import ColorMapper
+from src.mapping_store import MappingStore
+from src.svg_parser import parse_svg
+
+
+# --------------------------------------------------------------------------- #
+# Caching
+# --------------------------------------------------------------------------- #
+@st.cache_data(show_spinner=False)
+def cached_color_extract(path_str: str, mtime: float) -> dict[str, int]:
+    """Return ``{hex: usage_count}`` for an SVG, keyed by path + mtime."""
+    parsed = parse_svg(Path(path_str))
+    return {h: u.count for h, u in parsed.colors.items()}
+
+
+# --------------------------------------------------------------------------- #
+# Inline rendering
+# --------------------------------------------------------------------------- #
+def render_inline_svg(svg_bytes: bytes, *, height: int = 480) -> None:
+    """Render raw SVG bytes inline. Strips XML decl so HTML doesn't choke."""
+    text = svg_bytes.decode("utf-8", errors="replace")
+    if text.lstrip().startswith("<?xml"):
+        text = text.split("?>", 1)[1].lstrip()
+    wrapper = (
+        f'<div style="background:#fff;border:1px solid #e0e0e0;border-radius:6px;'
+        f'padding:8px;height:{height}px;overflow:auto;display:flex;'
+        f'align-items:center;justify-content:center;">{text}</div>'
+    )
+    st.markdown(wrapper, unsafe_allow_html=True)
+
+
+def status_badge(status: str) -> str:
+    color = {
+        "pending": "#9CA3AF",
+        "in_progress": "#F59E0B",
+        "reviewed": "#10B981",
+        "exported": "#3B82F6",
+    }.get(status, "#9CA3AF")
+    return (
+        f'<span style="background:{color};color:#fff;padding:2px 8px;'
+        f'border-radius:10px;font-size:0.8em;">{status}</span>'
+    )
+
+
+def color_swatch(hex_color: str, size: int = 22) -> str:
+    return (
+        f'<span style="display:inline-block;width:{size}px;height:{size}px;'
+        f'background:{hex_color};border:1px solid #aaa;border-radius:3px;'
+        f'vertical-align:middle;"></span>'
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Convenience accessors over st.session_state
+# --------------------------------------------------------------------------- #
+def fresh_mapper() -> ColorMapper:
+    """Build a ColorMapper from current config + live global map."""
+    cfg = st.session_state.config
+    store: MappingStore = st.session_state.store
+    return ColorMapper(global_map=store.load_global_map(), matching=cfg.matching)

--- a/illustration-color-edit/app/tab_batch.py
+++ b/illustration-color-edit/app/tab_batch.py
@@ -1,0 +1,57 @@
+"""Batch Export tab — convert reviewed (or all) illustrations and report results."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from src.library_manager import LibraryManager
+from src.mapping_store import MappingStore, merge_mappings
+from src.svg_writer import write_converted_svg
+
+
+def render() -> None:
+    st.subheader("Batch export")
+    library: LibraryManager = st.session_state.library
+    store: MappingStore = st.session_state.store
+    cfg = st.session_state.config
+
+    only_reviewed = st.checkbox(
+        "Only export reviewed illustrations", value=True, key="batch_reviewed"
+    )
+    st.markdown(f"**Output directory:** `{cfg.paths.output_dir}`")
+
+    entries = library.scan()
+    if only_reviewed:
+        entries = [e for e in entries if e.status == "reviewed"]
+
+    st.write(f"{len(entries)} illustration(s) queued.")
+
+    if st.button("Run batch export", type="primary", key="batch_run", width="content"):
+        if not entries:
+            st.warning("Nothing to export.")
+        else:
+            cfg.paths.output_dir.mkdir(parents=True, exist_ok=True)
+            global_map = store.load_global_map()
+            log_rows: list[dict] = []
+            progress = st.progress(0.0)
+            for i, e in enumerate(entries, start=1):
+                illu = store.load_illustration(e.filename)
+                merged = merge_mappings(global_map, illu.overrides)
+                dst = cfg.paths.output_dir / e.filename
+                report = write_converted_svg(e.path, merged, dst)
+                illu.with_status("exported")
+                store.save_illustration(illu)
+                log_rows.append({
+                    "file": e.filename,
+                    "replacements": report.replacements,
+                    "unmapped_colors": len(report.unmapped),
+                    "unmapped_list": ", ".join(sorted(report.unmapped)[:8]),
+                })
+                progress.progress(i / len(entries))
+            st.session_state.batch_report = log_rows
+            st.success(f"Exported {len(entries)} files to {cfg.paths.output_dir}.")
+
+    rows = st.session_state.get("batch_report")
+    if rows:
+        st.markdown("### Last run report")
+        st.dataframe(rows, width="stretch")

--- a/illustration-color-edit/app/tab_editor.py
+++ b/illustration-color-edit/app/tab_editor.py
@@ -1,0 +1,176 @@
+"""Editor tab — side-by-side preview and per-color mapping with suggestions."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from app.common import (
+    cached_color_extract,
+    color_swatch,
+    fresh_mapper,
+    render_inline_svg,
+    status_badge,
+)
+from src.color_mapper import MatchKind, gray_value, suggest_from_history
+from src.library_manager import LibraryManager
+from src.mapping_store import MappingStore, merge_mappings
+from src.print_safety import check_mapping
+from src.svg_writer import apply_mapping_with_report
+
+
+def render() -> None:
+    st.subheader("Editor")
+    library: LibraryManager = st.session_state.library
+    store: MappingStore = st.session_state.store
+    cfg = st.session_state.config
+
+    current = st.session_state.get("current_file")
+    if not current:
+        st.info("No illustration selected. Pick one in the **Library** tab.")
+        return
+
+    svg_path = cfg.paths.input_dir / current
+    if not svg_path.is_file():
+        st.error(f"{svg_path} no longer exists. Rescan in the Library tab.")
+        return
+
+    illu = store.load_illustration(current)
+    if illu.status == "pending":
+        illu.with_status("in_progress")
+        store.save_illustration(illu)
+
+    st.markdown(
+        f"**File:** `{current}` &nbsp; **Status:** {status_badge(illu.status)}",
+        unsafe_allow_html=True,
+    )
+
+    mtime = svg_path.stat().st_mtime
+    colors = cached_color_extract(str(svg_path), mtime)
+    if not colors:
+        st.warning("No concrete colors found in this SVG (may be all `none`/`url(...)` references).")
+        return
+
+    mapper = fresh_mapper().with_overrides(illu.overrides)
+    history = store.history()
+
+    picks: dict[str, str] = dict(st.session_state.editor_picks)
+
+    suggestions = {h: mapper.suggest(h) for h in sorted(colors)}
+    effective: dict[str, str] = {}
+    for src, sug in suggestions.items():
+        if src in picks:
+            effective[src] = picks[src]
+        elif src in illu.overrides:
+            effective[src] = illu.overrides[src]
+        elif sug.target is not None:
+            effective[src] = sug.target
+
+    full_mapping = merge_mappings(store.load_global_map(), effective)
+    converted_bytes, report = apply_mapping_with_report(svg_path, full_mapping)
+
+    left, right = st.columns(2)
+    with left:
+        st.markdown("**Original**")
+        render_inline_svg(svg_path.read_bytes(), height=480)
+    with right:
+        st.markdown("**Converted (live preview)**")
+        render_inline_svg(converted_bytes, height=480)
+
+    st.divider()
+    st.markdown(f"### Color mapping — {len(colors)} unique source colors")
+
+    safety_warnings = check_mapping(effective, cfg.print_safety)
+    safety_targets = {w.target for w in safety_warnings}
+
+    sorted_colors = sorted(colors.items(), key=lambda kv: -kv[1])
+    for src_hex, count in sorted_colors:
+        sug = suggestions[src_hex]
+        history_picks = suggest_from_history(src_hex, history)
+        with st.container(border=True):
+            row = st.columns([1, 2, 2, 3, 2])
+            row[0].markdown(
+                f"{color_swatch(src_hex)} <code>{src_hex}</code><br>"
+                f"<small>{count} uses</small>",
+                unsafe_allow_html=True,
+            )
+
+            if sug.kind is MatchKind.EXACT:
+                badge = "<span style='color:#10B981'>● exact</span>"
+                detail = sug.label or ""
+            elif sug.kind is MatchKind.NEAR:
+                badge = "<span style='color:#F59E0B'>● near</span>"
+                detail = (
+                    f"via <code>{sug.via}</code> · "
+                    f"Δ{cfg.matching.metric.upper()}={sug.distance:.2f}"
+                )
+            else:
+                badge = "<span style='color:#EF4444'>● none</span>"
+                detail = "no exact or near match"
+            row[1].markdown(f"{badge}<br><small>{detail}</small>", unsafe_allow_html=True)
+
+            initial = (
+                picks.get(src_hex)
+                or illu.overrides.get(src_hex)
+                or (sug.target if sug.target else "#888888")
+            )
+            picked = row[2].color_picker(
+                "target",
+                value=initial,
+                key=f"pick_{current}_{src_hex}",
+                label_visibility="collapsed",
+            ).upper()
+
+            if history_picks:
+                opts = [f"{t} ({c}x)" for t, c in history_picks[:5]]
+                chosen = row[3].selectbox(
+                    "history",
+                    options=["(keep current)"] + opts,
+                    key=f"hist_{current}_{src_hex}",
+                    label_visibility="collapsed",
+                )
+                if chosen != "(keep current)":
+                    picked = chosen.split(" ", 1)[0].upper()
+            else:
+                row[3].markdown("<small>no history yet</small>", unsafe_allow_html=True)
+
+            if picked in safety_targets:
+                row[4].warning("⚠ light for print")
+            elif gray_value(picked) <= 16:
+                row[4].caption("very dark — OK")
+            else:
+                row[4].caption(f"luminance {gray_value(picked)}")
+
+            picks[src_hex] = picked
+
+    st.session_state.editor_picks = picks
+
+    st.divider()
+    a1, a2, a3, a4 = st.columns([1, 1, 1, 3])
+    if a1.button("Save (keep status)", key="ed_save", width="content"):
+        illu.overrides = {k.upper(): v.upper() for k, v in picks.items()}
+        store.save_illustration(illu)
+        st.success(f"Saved {len(illu.overrides)} overrides for {current}.")
+    if a2.button("Save & mark reviewed", key="ed_review", width="content", type="primary"):
+        illu.overrides = {k.upper(): v.upper() for k, v in picks.items()}
+        illu.with_status("reviewed")
+        store.save_illustration(illu)
+        gm = store.load_global_map()
+        new_global = 0
+        for src, tgt in illu.overrides.items():
+            if src not in gm:
+                store.upsert_global_entry(src, tgt, label="auto-promoted from editor", notes="")
+                new_global += 1
+        st.success(
+            f"Saved & marked reviewed. {new_global} new entries promoted to the global map."
+        )
+    if a3.button("Promote ALL picks to global", key="ed_promote", width="content"):
+        for src, tgt in picks.items():
+            store.upsert_global_entry(src, tgt, label="manual promote", notes="")
+        st.success(f"Promoted {len(picks)} entries to the global map.")
+
+    if report.unmapped:
+        a4.warning(
+            f"{len(report.unmapped)} source colors are still unmapped: "
+            + ", ".join(sorted(report.unmapped)[:8])
+            + ("…" if len(report.unmapped) > 8 else "")
+        )

--- a/illustration-color-edit/app/tab_global_map.py
+++ b/illustration-color-edit/app/tab_global_map.py
@@ -1,0 +1,69 @@
+"""Global Map tab — view, edit, and add entries to the project-wide color map."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from app.common import color_swatch
+from src.mapping_store import MappingStore
+
+
+def render() -> None:
+    st.subheader("Global color map")
+    store: MappingStore = st.session_state.store
+
+    gm = store.load_global_map()
+    usage = store.usage_counts()
+
+    if not gm:
+        st.info("Global map is empty. Map a few colors in the Editor first.")
+    else:
+        header = st.columns([1, 2, 1, 2, 3, 1])
+        for i, label in enumerate(["Source", "Target", "Used in", "Label", "Notes", ""]):
+            header[i].markdown(f"**{label}**")
+
+        for src in sorted(gm):
+            entry = gm[src]
+            row = st.columns([1, 2, 1, 2, 3, 1])
+            row[0].markdown(
+                f"{color_swatch(src)} <code>{src}</code>",
+                unsafe_allow_html=True,
+            )
+            new_target = row[1].color_picker(
+                "target", value=entry["target"], key=f"gm_t_{src}",
+                label_visibility="collapsed",
+            ).upper()
+            row[2].write(usage.get(src, 0))
+            new_label = row[3].text_input(
+                "label", value=entry.get("label", ""), key=f"gm_l_{src}",
+                label_visibility="collapsed",
+            )
+            new_notes = row[4].text_input(
+                "notes", value=entry.get("notes", ""), key=f"gm_n_{src}",
+                label_visibility="collapsed",
+            )
+            if row[5].button("✕", key=f"gm_del_{src}", help="Remove entry"):
+                store.remove_global_entry(src)
+                st.rerun()
+
+            if (
+                new_target != entry["target"]
+                or new_label != entry.get("label", "")
+                or new_notes != entry.get("notes", "")
+            ):
+                store.upsert_global_entry(src, new_target, label=new_label, notes=new_notes)
+
+    st.divider()
+    st.markdown("**Add a new entry**")
+    with st.form("add_global", clear_on_submit=True):
+        f = st.columns([1, 1, 2, 3, 1])
+        nsrc = f[0].text_input("source hex", value="#")
+        ntgt = f[1].color_picker("target", value="#888888")
+        nlbl = f[2].text_input("label")
+        nnts = f[3].text_input("notes")
+        if f[4].form_submit_button("Add"):
+            if not nsrc.startswith("#") or len(nsrc) != 7:
+                st.error("Source must be #RRGGBB.")
+            else:
+                store.upsert_global_entry(nsrc.upper(), ntgt.upper(), label=nlbl, notes=nnts)
+                st.success(f"Added {nsrc.upper()} → {ntgt.upper()}.")

--- a/illustration-color-edit/app/tab_library.py
+++ b/illustration-color-edit/app/tab_library.py
@@ -1,0 +1,62 @@
+"""Library tab — list SVGs in input/ with status badges and quick actions."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from app.common import status_badge
+from src.library_manager import LibraryManager
+
+
+def render() -> None:
+    st.subheader("Library")
+    library: LibraryManager = st.session_state.library
+    cfg = st.session_state.config
+
+    cols = st.columns([3, 1, 1, 1])
+    cols[0].markdown(f"**Input directory:** `{cfg.paths.input_dir}`")
+
+    if cols[1].button("Rescan", key="lib_rescan", width="content"):
+        st.cache_data.clear()
+        st.rerun()
+
+    if cols[2].button("Open next pending", key="lib_open_next", width="content"):
+        nxt = library.next_pending()
+        if nxt:
+            st.session_state.current_file = nxt.filename
+            st.session_state.editor_picks = {}
+            st.success(f"Opened {nxt.filename}. Switch to the **Editor** tab.")
+        else:
+            st.info("No pending illustrations.")
+
+    counts = library.status_counts()
+    cols[3].markdown(
+        f"<div style='line-height:1.6'>"
+        f"{status_badge('pending')} {counts['pending']} &nbsp;"
+        f"{status_badge('in_progress')} {counts['in_progress']} &nbsp;"
+        f"{status_badge('reviewed')} {counts['reviewed']} &nbsp;"
+        f"{status_badge('exported')} {counts['exported']}"
+        f"</div>",
+        unsafe_allow_html=True,
+    )
+
+    entries = library.scan()
+    if not entries:
+        st.warning(f"No SVG files in {cfg.paths.input_dir}.")
+        return
+
+    header = st.columns([3, 1, 1, 1, 1, 1])
+    for i, label in enumerate(["File", "Status", "Overrides", "Size (KB)", "Modified", "Open"]):
+        header[i].markdown(f"**{label}**")
+
+    for e in entries:
+        row = st.columns([3, 1, 1, 1, 1, 1])
+        row[0].write(e.filename)
+        row[1].markdown(status_badge(e.status), unsafe_allow_html=True)
+        row[2].write(e.override_count)
+        row[3].write(f"{e.size_kb:.1f}")
+        row[4].write(e.modified_iso[:19].replace("T", " ") if e.modified_iso else "—")
+        if row[5].button("Open", key=f"open_{e.filename}", width="content"):
+            st.session_state.current_file = e.filename
+            st.session_state.editor_picks = {}
+            st.toast(f"Opened {e.filename}. Switch to the **Editor** tab.")

--- a/illustration-color-edit/app/tab_settings.py
+++ b/illustration-color-edit/app/tab_settings.py
@@ -1,0 +1,35 @@
+"""Settings tab — read-only view of resolved config (edit config.json directly)."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def render() -> None:
+    st.subheader("Settings")
+    cfg = st.session_state.config
+    st.caption(f"Config file: `{cfg.source_path}`")
+
+    st.markdown("### Paths")
+    st.write({
+        "input_dir": str(cfg.paths.input_dir),
+        "output_dir": str(cfg.paths.output_dir),
+        "metadata_dir": str(cfg.paths.metadata_dir),
+    })
+    st.caption("Edit `config.json` directly to change paths, then restart the app.")
+
+    st.markdown("### Matching")
+    st.write({
+        "nearest_enabled": cfg.matching.nearest_enabled,
+        "metric": cfg.matching.metric,
+        "threshold": cfg.matching.threshold,
+    })
+
+    st.markdown("### Print safety")
+    st.write({
+        "min_gray_value": cfg.print_safety.min_gray_value,
+        "warn_only": cfg.print_safety.warn_only,
+    })
+
+    st.markdown("### Logging")
+    st.write({"level": cfg.log_level})

--- a/illustration-color-edit/config.json.example
+++ b/illustration-color-edit/config.json.example
@@ -1,0 +1,36 @@
+{
+  "global_color_map": {
+    "#E74C3C": {
+      "target": "#333333",
+      "label": "red / bad",
+      "notes": "Strong negative semantic. Map to dark gray for high contrast."
+    },
+    "#2ECC71": {
+      "target": "#CCCCCC",
+      "label": "green / good",
+      "notes": "Positive semantic. Light gray reads as 'good' in print."
+    },
+    "#F1C40F": {
+      "target": "#888888",
+      "label": "yellow / warning",
+      "notes": "Mid gray for caution / neutral-warn states."
+    }
+  },
+  "matching": {
+    "nearest_enabled": true,
+    "metric": "lab",
+    "threshold": 10.0
+  },
+  "print_safety": {
+    "min_gray_value": "#EEEEEE",
+    "warn_only": true
+  },
+  "paths": {
+    "input_dir": "./input",
+    "output_dir": "./output",
+    "metadata_dir": "./metadata"
+  },
+  "logging": {
+    "level": "INFO"
+  }
+}

--- a/illustration-color-edit/launch_app.bat
+++ b/illustration-color-edit/launch_app.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Launch the SVG color-to-grayscale Streamlit app on Windows.
+REM Uses the project's local .venv if present; otherwise falls back to system Python.
+
+setlocal
+cd /d "%~dp0"
+
+if exist ".venv\Scripts\python.exe" (
+    set "PYEXE=.venv\Scripts\python.exe"
+) else (
+    echo [warn] No .venv found in %CD%. Falling back to system python.
+    set "PYEXE=python"
+)
+
+"%PYEXE%" -m streamlit run app\app.py %*
+
+endlocal

--- a/illustration-color-edit/requirements.txt
+++ b/illustration-color-edit/requirements.txt
@@ -1,0 +1,3 @@
+streamlit==1.40.2
+lxml==5.3.0
+pytest==8.3.4

--- a/illustration-color-edit/src/__init__.py
+++ b/illustration-color-edit/src/__init__.py
@@ -1,0 +1,3 @@
+"""Illustration Color Edit — SVG color-to-grayscale conversion pipeline."""
+
+__version__ = "0.1.0"

--- a/illustration-color-edit/src/cli.py
+++ b/illustration-color-edit/src/cli.py
@@ -1,0 +1,290 @@
+"""
+Batch CLI for the SVG color-to-grayscale conversion pipeline.
+
+Run with::
+
+    python -m src.cli --help
+
+Subcommands:
+
+  ``status``     Print per-file status (pending / in_progress / reviewed / exported).
+  ``inspect``    Show the colors found in a single SVG and proposed mapping.
+  ``convert``    Convert all (or only ``--only-reviewed``) SVGs in ``input/``
+                 to ``output/`` using the current global map + per-file
+                 overrides. Marks each converted file as ``exported``.
+
+Exit code is non-zero if:
+
+  * print-safety warnings occur and ``print_safety.warn_only`` is ``False``
+  * any file failed to convert
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from .color_mapper import ColorMapper, MatchKind
+from .config import AppConfig, configure_logging, load_config
+from .library_manager import LibraryEntry, LibraryManager
+from .mapping_store import MappingStore, merge_mappings
+from .print_safety import SafetyWarning, check_mapping
+from .svg_parser import parse_svg
+from .svg_writer import write_converted_svg
+
+log = logging.getLogger("color_edit.cli")
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+@dataclass
+class RunSummary:
+    converted: list[str] = field(default_factory=list)
+    skipped: list[tuple[str, str]] = field(default_factory=list)  # (file, reason)
+    failed: list[tuple[str, str]] = field(default_factory=list)
+    unmapped_per_file: dict[str, list[str]] = field(default_factory=dict)
+    safety_warnings: list[SafetyWarning] = field(default_factory=list)
+
+    def to_text(self) -> str:
+        lines = []
+        lines.append(f"Converted: {len(self.converted)}")
+        lines.append(f"Skipped:   {len(self.skipped)}")
+        lines.append(f"Failed:    {len(self.failed)}")
+
+        if self.skipped:
+            lines.append("")
+            lines.append("Skipped:")
+            for f, why in self.skipped:
+                lines.append(f"  - {f}  ({why})")
+
+        if self.failed:
+            lines.append("")
+            lines.append("Failed:")
+            for f, why in self.failed:
+                lines.append(f"  - {f}: {why}")
+
+        files_with_unmapped = {f: u for f, u in self.unmapped_per_file.items() if u}
+        if files_with_unmapped:
+            lines.append("")
+            lines.append("Unmapped colors per file:")
+            for f, colors in files_with_unmapped.items():
+                lines.append(f"  - {f}: {', '.join(sorted(colors))}")
+
+        if self.safety_warnings:
+            lines.append("")
+            lines.append("Print-safety warnings:")
+            for w in self.safety_warnings:
+                lines.append(f"  - {w}")
+
+        return "\n".join(lines)
+
+
+def _build_pieces(cfg: AppConfig) -> tuple[MappingStore, LibraryManager]:
+    cfg_path = cfg.source_path or Path("config.json")
+    store = MappingStore(cfg_path, cfg.paths.metadata_dir)
+    library = LibraryManager(cfg.paths.input_dir, store)
+    return store, library
+
+
+# --------------------------------------------------------------------------- #
+# Subcommand: status
+# --------------------------------------------------------------------------- #
+def cmd_status(args: argparse.Namespace, cfg: AppConfig) -> int:
+    _, library = _build_pieces(cfg)
+    entries = library.scan()
+    if not entries:
+        print(f"No SVG files in {cfg.paths.input_dir}.")
+        return 0
+    counts = library.status_counts()
+    print(f"Library: {cfg.paths.input_dir}")
+    print(f"  pending={counts['pending']}  in_progress={counts['in_progress']}  "
+          f"reviewed={counts['reviewed']}  exported={counts['exported']}")
+    print()
+    print(f"{'STATUS':<13} {'OVERRIDES':>9} {'SIZE(KB)':>9}  FILE")
+    for e in entries:
+        print(f"{e.status:<13} {e.override_count:>9} {e.size_kb:>9.1f}  {e.filename}")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Subcommand: inspect
+# --------------------------------------------------------------------------- #
+def cmd_inspect(args: argparse.Namespace, cfg: AppConfig) -> int:
+    store, _ = _build_pieces(cfg)
+    path = Path(args.path)
+    if not path.is_file():
+        log.error("File not found: %s", path)
+        return 2
+    parsed = parse_svg(path)
+    if not parsed.colors:
+        print(f"{path.name}: no concrete colors found.")
+        return 0
+
+    illu = store.load_illustration(path.name)
+    mapper = ColorMapper(global_map=store.load_global_map(), matching=cfg.matching)
+    mapper = mapper.with_overrides(illu.overrides)
+
+    print(f"{path.name}: {parsed.unique_color_count} unique colors")
+    print(f"{'SOURCE':<10} {'COUNT':>5}  {'KIND':<6}  {'TARGET':<10}  DETAILS")
+    for src in sorted(parsed.colors, key=lambda h: -parsed.colors[h].count):
+        usage = parsed.colors[src]
+        s = mapper.suggest(src)
+        target = s.target or "—"
+        detail = ""
+        if s.kind is MatchKind.NEAR:
+            detail = f"near {s.via} (Δ{cfg.matching.metric.upper()}={s.distance:.2f})"
+        elif s.kind is MatchKind.EXACT and s.label:
+            detail = s.label
+        elif s.kind is MatchKind.NONE:
+            detail = "no match — needs manual mapping"
+        print(f"{src:<10} {usage.count:>5}  {s.kind.value:<6}  {target:<10}  {detail}")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Subcommand: convert
+# --------------------------------------------------------------------------- #
+def cmd_convert(args: argparse.Namespace, cfg: AppConfig) -> int:
+    store, library = _build_pieces(cfg)
+    cfg.paths.output_dir.mkdir(parents=True, exist_ok=True)
+
+    entries = library.scan()
+    if args.only_reviewed:
+        entries = [e for e in entries if e.status == "reviewed"]
+    if args.file:
+        wanted = {Path(f).name for f in args.file}
+        entries = [e for e in entries if e.filename in wanted]
+
+    if not entries:
+        log.warning("No matching files to convert.")
+        return 0
+
+    global_map = store.load_global_map()
+    summary = RunSummary()
+
+    for entry in entries:
+        try:
+            _convert_one(
+                entry, store, global_map, cfg, summary,
+                dry_run=args.dry_run, force=args.force,
+            )
+        except Exception as exc:  # pragma: no cover - defensive top-level
+            log.exception("Failed to convert %s", entry.filename)
+            summary.failed.append((entry.filename, str(exc)))
+
+    print(summary.to_text())
+
+    # Exit code policy
+    if summary.failed:
+        return 3
+    if summary.safety_warnings and not cfg.print_safety.warn_only:
+        return 4
+    return 0
+
+
+def _convert_one(
+    entry: LibraryEntry,
+    store: MappingStore,
+    global_map: dict[str, dict[str, str]],
+    cfg: AppConfig,
+    summary: RunSummary,
+    *,
+    dry_run: bool,
+    force: bool,
+) -> None:
+    illu = store.load_illustration(entry.filename)
+    merged = merge_mappings(global_map, illu.overrides)
+
+    parsed = parse_svg(entry.path)
+    unmapped_here = [h for h in parsed.colors if h not in merged]
+
+    # Skip files that have unmapped colors AND no saved overrides AND aren't
+    # already marked reviewed — unless --force.
+    needs_review = (
+        unmapped_here
+        and not illu.overrides
+        and entry.status != "reviewed"
+        and not force
+    )
+    if needs_review:
+        summary.skipped.append((entry.filename, f"{len(unmapped_here)} unmapped colors"))
+        summary.unmapped_per_file[entry.filename] = unmapped_here
+        return
+
+    summary.unmapped_per_file[entry.filename] = unmapped_here
+
+    file_warnings = check_mapping(
+        {h: merged[h] for h in parsed.colors if h in merged},
+        cfg.print_safety,
+    )
+    summary.safety_warnings.extend(file_warnings)
+
+    if dry_run:
+        log.info("[dry-run] %s would write to %s", entry.filename,
+                 cfg.paths.output_dir / entry.filename)
+        summary.converted.append(entry.filename)
+        return
+
+    dst = cfg.paths.output_dir / entry.filename
+    write_converted_svg(entry.path, merged, dst)
+    illu.with_status("exported")
+    store.save_illustration(illu)
+    summary.converted.append(entry.filename)
+
+
+# --------------------------------------------------------------------------- #
+# Argparse wiring
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="color_edit",
+        description="SVG color-to-grayscale batch processor.",
+    )
+    p.add_argument("--config", type=Path, default=None,
+                   help="Path to a config.json (default: project_root/config.json).")
+    p.add_argument("-v", "--verbose", action="store_true", help="DEBUG-level logging.")
+
+    sub = p.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="List library status counts and per-file rows.")
+
+    p_inspect = sub.add_parser("inspect", help="Inspect one SVG.")
+    p_inspect.add_argument("path", type=str, help="Path to an SVG file.")
+
+    p_convert = sub.add_parser("convert", help="Batch convert SVGs.")
+    p_convert.add_argument("--only-reviewed", action="store_true",
+                           help="Only process files with status 'reviewed'.")
+    p_convert.add_argument("--file", action="append", default=[],
+                           help="Convert specific file(s). Can be passed multiple times.")
+    p_convert.add_argument("--force", action="store_true",
+                           help="Convert even if unmapped colors are present.")
+    p_convert.add_argument("--dry-run", action="store_true",
+                           help="Don't write files; just produce the report.")
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    cfg = load_config(args.config)
+    cfg.ensure_dirs()
+    configure_logging("DEBUG" if args.verbose else cfg.log_level)
+
+    if args.command == "status":
+        return cmd_status(args, cfg)
+    if args.command == "inspect":
+        return cmd_inspect(args, cfg)
+    if args.command == "convert":
+        return cmd_convert(args, cfg)
+    parser.error(f"Unknown command: {args.command}")
+    return 2  # unreachable
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/illustration-color-edit/src/color_mapper.py
+++ b/illustration-color-edit/src/color_mapper.py
@@ -1,0 +1,315 @@
+"""
+Color mapping engine.
+
+Given a source color extracted from an SVG, decide what target color it
+should be remapped to:
+
+  1. **Exact match** — the source hex is a key in the global color map.
+  2. **Nearest match** — within a configurable distance threshold (CIE
+     Lab ΔE or RGB Euclidean) of an existing key.
+  3. **No match** — must be assigned manually.
+
+The mapper is pure: it knows nothing about files. The caller passes in a
+``global_map`` (dict keyed by canonical ``#RRGGBB`` uppercase) and a
+:class:`MatchingConfig` (from ``src.config``).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, Optional
+
+from .config import MatchingConfig
+
+log = logging.getLogger(__name__)
+
+
+class MatchKind(str, Enum):
+    EXACT = "exact"
+    NEAR = "near"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class Suggestion:
+    """A proposed mapping for one source color."""
+
+    source: str                       # canonical source hex (#RRGGBB upper)
+    target: Optional[str]             # canonical target hex, or None if NONE
+    kind: MatchKind
+    distance: float = 0.0
+    via: Optional[str] = None         # the global-map key that matched (for NEAR)
+    label: Optional[str] = None
+    notes: Optional[str] = None
+
+    @property
+    def is_actionable(self) -> bool:
+        """True if this suggestion can be applied without user input."""
+        return self.kind is not MatchKind.NONE and self.target is not None
+
+
+# --------------------------------------------------------------------------- #
+# Color space conversions and distance metrics
+# --------------------------------------------------------------------------- #
+def hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    """``#RRGGBB`` -> ``(r, g, b)`` in 0..255."""
+    h = hex_color.lstrip("#")
+    if len(h) != 6:
+        raise ValueError(f"Expected 6-digit hex, got {hex_color!r}")
+    return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16)
+
+
+def rgb_to_hex(rgb: tuple[int, int, int]) -> str:
+    return "#{:02X}{:02X}{:02X}".format(*rgb)
+
+
+def _srgb_to_linear(c: float) -> float:
+    """Inverse sRGB gamma. ``c`` is in 0..1."""
+    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def rgb_to_xyz(r: int, g: int, b: int) -> tuple[float, float, float]:
+    """sRGB (0..255) -> CIE XYZ (D65, scaled 0..100)."""
+    rl = _srgb_to_linear(r / 255.0)
+    gl = _srgb_to_linear(g / 255.0)
+    bl = _srgb_to_linear(b / 255.0)
+    # sRGB D65 matrix
+    x = (rl * 0.4124564 + gl * 0.3575761 + bl * 0.1804375) * 100
+    y = (rl * 0.2126729 + gl * 0.7151522 + bl * 0.0721750) * 100
+    z = (rl * 0.0193339 + gl * 0.1191920 + bl * 0.9503041) * 100
+    return x, y, z
+
+
+# D65 reference white, scaled 0..100
+_REF_X, _REF_Y, _REF_Z = 95.047, 100.000, 108.883
+
+
+def _f_lab(t: float) -> float:
+    delta = 6 / 29
+    if t > delta**3:
+        return t ** (1 / 3)
+    return t / (3 * delta**2) + 4 / 29
+
+
+def xyz_to_lab(x: float, y: float, z: float) -> tuple[float, float, float]:
+    """CIE XYZ -> CIE L*a*b*."""
+    fx = _f_lab(x / _REF_X)
+    fy = _f_lab(y / _REF_Y)
+    fz = _f_lab(z / _REF_Z)
+    L = 116 * fy - 16
+    a = 500 * (fx - fy)
+    b = 200 * (fy - fz)
+    return L, a, b
+
+
+def hex_to_lab(hex_color: str) -> tuple[float, float, float]:
+    return xyz_to_lab(*rgb_to_xyz(*hex_to_rgb(hex_color)))
+
+
+def delta_e_lab(a: tuple[float, float, float], b: tuple[float, float, float]) -> float:
+    """ΔE76 (Euclidean distance in CIE L*a*b*)."""
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+
+def rgb_distance(a: tuple[int, int, int], b: tuple[int, int, int]) -> float:
+    """Euclidean distance in sRGB."""
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+
+def color_distance(hex_a: str, hex_b: str, metric: str = "lab") -> float:
+    """
+    Distance between two ``#RRGGBB`` colors.
+
+    ``metric`` is ``"lab"`` (CIE ΔE76) or ``"rgb"`` (Euclidean in 0..255).
+    """
+    metric = metric.lower()
+    if metric == "lab":
+        return delta_e_lab(hex_to_lab(hex_a), hex_to_lab(hex_b))
+    if metric == "rgb":
+        return rgb_distance(hex_to_rgb(hex_a), hex_to_rgb(hex_b))
+    raise ValueError(f"Unknown metric: {metric!r}. Use 'lab' or 'rgb'.")
+
+
+def is_grayscale(hex_color: str, tolerance: int = 2) -> bool:
+    """True if R, G, B channels are within ``tolerance`` of each other."""
+    r, g, b = hex_to_rgb(hex_color)
+    return max(r, g, b) - min(r, g, b) <= tolerance
+
+
+def gray_value(hex_color: str) -> int:
+    """Perceptual luminance 0..255 (Rec. 709)."""
+    r, g, b = hex_to_rgb(hex_color)
+    return round(0.2126 * r + 0.7152 * g + 0.0722 * b)
+
+
+# --------------------------------------------------------------------------- #
+# Mapper
+# --------------------------------------------------------------------------- #
+@dataclass
+class ColorMapper:
+    """
+    Suggest target colors for source colors using a global color map plus
+    optional nearest-color matching.
+
+    The global map is the dict from ``config.json``:
+
+        {"#E74C3C": {"target": "#333333", "label": "...", "notes": "..."}}
+
+    Per-illustration overrides are layered on top via :meth:`with_overrides`.
+    """
+
+    global_map: dict[str, dict[str, str]] = field(default_factory=dict)
+    matching: MatchingConfig = field(default_factory=MatchingConfig)
+    overrides: dict[str, str] = field(default_factory=dict)
+    _lab_cache: dict[str, tuple[float, float, float]] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # Normalize keys to canonical form.
+        self.global_map = {k.upper(): v for k, v in self.global_map.items()}
+        self.overrides = {k.upper(): v.upper() for k, v in self.overrides.items()}
+
+    # ----- caching helpers ------------------------------------------------- #
+    def _lab(self, hex_color: str) -> tuple[float, float, float]:
+        cached = self._lab_cache.get(hex_color)
+        if cached is None:
+            cached = hex_to_lab(hex_color)
+            self._lab_cache[hex_color] = cached
+        return cached
+
+    def _distance(self, a: str, b: str) -> float:
+        if self.matching.metric == "lab":
+            return delta_e_lab(self._lab(a), self._lab(b))
+        return rgb_distance(hex_to_rgb(a), hex_to_rgb(b))
+
+    # ----- public API ------------------------------------------------------ #
+    def with_overrides(self, overrides: dict[str, str]) -> "ColorMapper":
+        """Return a shallow copy with per-illustration overrides applied."""
+        merged = dict(self.overrides)
+        merged.update({k.upper(): v.upper() for k, v in overrides.items()})
+        return ColorMapper(
+            global_map=self.global_map,
+            matching=self.matching,
+            overrides=merged,
+        )
+
+    def suggest(self, source_hex: str) -> Suggestion:
+        """Suggest a target for ``source_hex``."""
+        src = source_hex.upper()
+
+        # Per-illustration override always wins.
+        if src in self.overrides:
+            return Suggestion(
+                source=src,
+                target=self.overrides[src],
+                kind=MatchKind.EXACT,
+                distance=0.0,
+                via=src,
+                label="override",
+            )
+
+        # Exact match against the global map.
+        if src in self.global_map:
+            entry = self.global_map[src]
+            return Suggestion(
+                source=src,
+                target=entry["target"].upper(),
+                kind=MatchKind.EXACT,
+                distance=0.0,
+                via=src,
+                label=entry.get("label"),
+                notes=entry.get("notes"),
+            )
+
+        # Optional nearest match.
+        if self.matching.nearest_enabled and self.global_map:
+            best_key, best_dist = self._closest(src)
+            if best_key is not None and best_dist <= self.matching.threshold:
+                entry = self.global_map[best_key]
+                return Suggestion(
+                    source=src,
+                    target=entry["target"].upper(),
+                    kind=MatchKind.NEAR,
+                    distance=best_dist,
+                    via=best_key,
+                    label=entry.get("label"),
+                    notes=entry.get("notes"),
+                )
+
+        return Suggestion(source=src, target=None, kind=MatchKind.NONE)
+
+    def suggest_many(self, sources: Iterable[str]) -> list[Suggestion]:
+        return [self.suggest(s) for s in sources]
+
+    def resolve(
+        self,
+        source_hex: str,
+        manual: Optional[str] = None,
+    ) -> Optional[str]:
+        """
+        Return the concrete target hex for ``source_hex``.
+
+        Resolution order:
+          1. ``manual`` if provided (validated to ``#RRGGBB``)
+          2. :meth:`suggest` if it returns an actionable suggestion
+          3. ``None`` (caller must handle unmapped)
+        """
+        if manual:
+            m = manual.upper()
+            if not (m.startswith("#") and len(m) == 7):
+                raise ValueError(f"Manual override must be #RRGGBB, got {manual!r}")
+            return m
+        s = self.suggest(source_hex)
+        return s.target
+
+    def apply_to_palette(
+        self,
+        palette: Iterable[str],
+        manual: Optional[dict[str, str]] = None,
+    ) -> dict[str, Optional[str]]:
+        """
+        Resolve every color in ``palette`` to a target.
+
+        ``manual`` is an optional dict of explicit user picks
+        (source_hex -> target_hex) that override suggestions.
+        """
+        manual_norm = {k.upper(): v.upper() for k, v in (manual or {}).items()}
+        return {
+            src.upper(): self.resolve(src, manual=manual_norm.get(src.upper()))
+            for src in palette
+        }
+
+    # ----- internals ------------------------------------------------------- #
+    def _closest(self, src: str) -> tuple[Optional[str], float]:
+        best_key: Optional[str] = None
+        best_dist = math.inf
+        for key in self.global_map:
+            d = self._distance(src, key)
+            if d < best_dist:
+                best_dist = d
+                best_key = key
+        return best_key, best_dist
+
+
+# --------------------------------------------------------------------------- #
+# Cross-library suggestions
+# --------------------------------------------------------------------------- #
+def suggest_from_history(
+    source_hex: str,
+    history: dict[str, dict[str, int]],
+) -> list[tuple[str, int]]:
+    """
+    Given the cross-library history of how ``source_hex`` has been mapped
+    in other illustrations, return ``[(target_hex, count), ...]`` sorted by
+    most-used first.
+
+    ``history`` shape: ``{source_hex: {target_hex: count}}``.
+    """
+    src = source_hex.upper()
+    by_target = history.get(src, {})
+    return sorted(
+        ((t.upper(), c) for t, c in by_target.items()),
+        key=lambda kv: (-kv[1], kv[0]),
+    )

--- a/illustration-color-edit/src/config.py
+++ b/illustration-color-edit/src/config.py
@@ -1,0 +1,131 @@
+"""
+Configuration loader for the illustration-color-edit project.
+
+Single source of truth: ``config.json`` in the project root.
+Falls back to ``config.json.example`` if no real config exists yet (useful
+on a fresh checkout — the app launches with sensible defaults instead of
+crashing).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass
+class MatchingConfig:
+    nearest_enabled: bool = True
+    metric: str = "lab"
+    threshold: float = 10.0
+
+
+@dataclass
+class PrintSafetyConfig:
+    min_gray_value: str = "#EEEEEE"
+    warn_only: bool = True
+
+
+@dataclass
+class PathsConfig:
+    input_dir: Path = field(default_factory=lambda: PROJECT_ROOT / "input")
+    output_dir: Path = field(default_factory=lambda: PROJECT_ROOT / "output")
+    metadata_dir: Path = field(default_factory=lambda: PROJECT_ROOT / "metadata")
+
+
+@dataclass
+class AppConfig:
+    """Resolved application config. Use ``load_config()`` to construct."""
+
+    global_color_map: dict[str, dict[str, str]] = field(default_factory=dict)
+    matching: MatchingConfig = field(default_factory=MatchingConfig)
+    print_safety: PrintSafetyConfig = field(default_factory=PrintSafetyConfig)
+    paths: PathsConfig = field(default_factory=PathsConfig)
+    log_level: str = "INFO"
+    source_path: Optional[Path] = None
+
+    def ensure_dirs(self) -> None:
+        """Create the configured input/output/metadata directories if missing."""
+        for p in (self.paths.input_dir, self.paths.output_dir, self.paths.metadata_dir):
+            p.mkdir(parents=True, exist_ok=True)
+
+
+def _resolve_path(raw: str, base: Path) -> Path:
+    p = Path(raw)
+    return p if p.is_absolute() else (base / p).resolve()
+
+
+def load_config(path: Optional[Path] = None) -> AppConfig:
+    """
+    Load and validate config from ``path`` (default: project_root/config.json).
+
+    Resolution order:
+      1. explicit ``path`` argument
+      2. ``PROJECT_ROOT/config.json``
+      3. ``PROJECT_ROOT/config.json.example``  (fallback for fresh checkouts)
+      4. built-in defaults                     (last resort)
+    """
+    candidates: list[Path] = []
+    if path is not None:
+        candidates.append(path)
+    candidates.append(PROJECT_ROOT / "config.json")
+    candidates.append(PROJECT_ROOT / "config.json.example")
+
+    chosen: Optional[Path] = None
+    for c in candidates:
+        if c.is_file():
+            chosen = c
+            break
+
+    if chosen is None:
+        log.warning("No config.json found; using built-in defaults.")
+        return AppConfig()
+
+    log.info("Loading config from %s", chosen)
+    raw: dict[str, Any] = json.loads(chosen.read_text(encoding="utf-8"))
+
+    cfg = AppConfig(source_path=chosen)
+    cfg.global_color_map = {
+        k.upper(): v for k, v in raw.get("global_color_map", {}).items()
+    }
+
+    matching = raw.get("matching", {})
+    cfg.matching = MatchingConfig(
+        nearest_enabled=bool(matching.get("nearest_enabled", True)),
+        metric=str(matching.get("metric", "lab")).lower(),
+        threshold=float(matching.get("threshold", 10.0)),
+    )
+
+    safety = raw.get("print_safety", {})
+    cfg.print_safety = PrintSafetyConfig(
+        min_gray_value=str(safety.get("min_gray_value", "#EEEEEE")).upper(),
+        warn_only=bool(safety.get("warn_only", True)),
+    )
+
+    paths = raw.get("paths", {})
+    base = chosen.parent
+    cfg.paths = PathsConfig(
+        input_dir=_resolve_path(paths.get("input_dir", "./input"), base),
+        output_dir=_resolve_path(paths.get("output_dir", "./output"), base),
+        metadata_dir=_resolve_path(paths.get("metadata_dir", "./metadata"), base),
+    )
+
+    cfg.log_level = str(raw.get("logging", {}).get("level", "INFO")).upper()
+    return cfg
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Configure root logger once. Idempotent."""
+    logging.basicConfig(
+        level=getattr(logging, level, logging.INFO),
+        format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )

--- a/illustration-color-edit/src/library_manager.py
+++ b/illustration-color-edit/src/library_manager.py
@@ -1,0 +1,127 @@
+"""
+Library manager — scan ``input_dir`` for SVGs and combine each file with its
+:class:`IllustrationMapping` from the metadata store to produce a unified
+view (filename, size, modified time, status, override count).
+
+This module owns no state beyond the filesystem; it's a thin read layer over
+the input directory plus :class:`MappingStore`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+from .mapping_store import IllustrationMapping, MappingStore, Status
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class LibraryEntry:
+    """One row in the Library tab."""
+
+    filename: str               # basename, e.g. "figure-01.svg"
+    path: Path                  # absolute path on disk
+    size_bytes: int
+    modified_iso: str
+    status: Status
+    override_count: int
+    has_metadata: bool
+    notes: str = ""
+
+    @property
+    def size_kb(self) -> float:
+        return self.size_bytes / 1024.0
+
+
+@dataclass
+class LibraryManager:
+    """
+    Scan ``input_dir`` for ``.svg`` files and join them with metadata.
+
+    Use :meth:`scan` to get fresh entries. The manager itself is stateless.
+    """
+
+    input_dir: Path
+    store: MappingStore
+
+    def __post_init__(self) -> None:
+        self.input_dir = Path(self.input_dir)
+
+    # ----- discovery ------------------------------------------------------- #
+    def list_svg_paths(self) -> list[Path]:
+        """Return sorted paths to all ``.svg`` files in ``input_dir``."""
+        if not self.input_dir.is_dir():
+            log.warning("Input dir %s does not exist.", self.input_dir)
+            return []
+        # Match both .svg and .SVG, no recursion (illustrations live flat in input/).
+        out: list[Path] = []
+        for p in self.input_dir.iterdir():
+            if p.is_file() and p.suffix.lower() == ".svg":
+                out.append(p)
+        out.sort(key=lambda p: p.name.lower())
+        return out
+
+    # ----- scan ------------------------------------------------------------ #
+    def scan(self) -> list[LibraryEntry]:
+        """Build :class:`LibraryEntry` rows for every SVG in ``input_dir``."""
+        entries: list[LibraryEntry] = []
+        for path in self.list_svg_paths():
+            entries.append(self._entry_for(path))
+        return entries
+
+    def _entry_for(self, path: Path) -> LibraryEntry:
+        try:
+            stat = path.stat()
+            size = stat.st_size
+            mtime_iso = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(timespec="seconds")
+        except OSError as exc:
+            log.warning("Cannot stat %s: %s", path, exc)
+            size = 0
+            mtime_iso = ""
+
+        meta_path = self.store.metadata_path_for(path.name)
+        has_meta = meta_path.is_file()
+        if has_meta:
+            mapping = self.store.load_illustration(path.name)
+        else:
+            mapping = IllustrationMapping(filename=path.name)
+        return LibraryEntry(
+            filename=path.name,
+            path=path,
+            size_bytes=size,
+            modified_iso=mtime_iso,
+            status=mapping.status,
+            override_count=len(mapping.overrides),
+            has_metadata=has_meta,
+            notes=mapping.notes,
+        )
+
+    # ----- queries --------------------------------------------------------- #
+    def by_status(self, status: Status) -> list[LibraryEntry]:
+        return [e for e in self.scan() if e.status == status]
+
+    def next_pending(self) -> Optional[LibraryEntry]:
+        """Return the first entry whose status is ``pending``, or ``None``."""
+        for e in self.scan():
+            if e.status == "pending":
+                return e
+        return None
+
+    def status_counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {"pending": 0, "in_progress": 0, "reviewed": 0, "exported": 0}
+        for e in self.scan():
+            counts[e.status] = counts.get(e.status, 0) + 1
+        return counts
+
+    # ----- mutations ------------------------------------------------------- #
+    def mark(self, filename: str, status: Status) -> IllustrationMapping:
+        """Set the status for one illustration. Persists immediately."""
+        mapping = self.store.load_illustration(filename)
+        mapping.with_status(status)
+        self.store.save_illustration(mapping)
+        return mapping

--- a/illustration-color-edit/src/mapping_store.py
+++ b/illustration-color-edit/src/mapping_store.py
@@ -1,0 +1,294 @@
+"""
+Persistence for the global color map and per-illustration overrides.
+
+Two stores:
+
+* **Global color map** lives in ``config.json`` under ``global_color_map``.
+  This is the canonical "this red always becomes this gray" registry shared
+  across the whole book.
+
+* **Per-illustration mapping** lives in ``metadata/<filename>.mapping.json``.
+  It records: status (pending / in_progress / reviewed / exported), per-file
+  overrides, last-updated timestamp, and free-form notes.
+
+The store also computes a cross-library *history*: for each source color,
+how many distinct illustrations have mapped it to each target. The Editor
+tab uses this to surface suggestions like "the red #E74C3C was previously
+mapped to #333333 in 4 other illustrations — reuse?".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Literal, Optional
+
+log = logging.getLogger(__name__)
+
+
+Status = Literal["pending", "in_progress", "reviewed", "exported"]
+VALID_STATUSES: tuple[Status, ...] = ("pending", "in_progress", "reviewed", "exported")
+
+
+# --------------------------------------------------------------------------- #
+# Per-illustration mapping
+# --------------------------------------------------------------------------- #
+@dataclass
+class IllustrationMapping:
+    """In-memory representation of ``metadata/<name>.mapping.json``."""
+
+    filename: str
+    status: Status = "pending"
+    overrides: dict[str, str] = field(default_factory=dict)
+    updated_at: str = ""
+    notes: str = ""
+
+    def touch(self) -> None:
+        self.updated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    def with_status(self, new_status: Status) -> "IllustrationMapping":
+        if new_status not in VALID_STATUSES:
+            raise ValueError(f"Invalid status {new_status!r}. Allowed: {VALID_STATUSES}")
+        self.status = new_status
+        self.touch()
+        return self
+
+    def to_dict(self) -> dict[str, object]:
+        d = asdict(self)
+        # Normalize hex case in stored data.
+        d["overrides"] = {k.upper(): v.upper() for k, v in self.overrides.items()}
+        return d
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, object]) -> "IllustrationMapping":
+        overrides_raw = raw.get("overrides") or {}
+        if not isinstance(overrides_raw, dict):
+            raise ValueError(f"'overrides' must be a dict, got {type(overrides_raw).__name__}")
+        return cls(
+            filename=str(raw.get("filename", "")),
+            status=_coerce_status(raw.get("status", "pending")),
+            overrides={str(k).upper(): str(v).upper() for k, v in overrides_raw.items()},
+            updated_at=str(raw.get("updated_at", "")),
+            notes=str(raw.get("notes", "")),
+        )
+
+
+def _coerce_status(value: object) -> Status:
+    s = str(value).lower()
+    if s not in VALID_STATUSES:
+        log.warning("Unknown status %r; defaulting to 'pending'.", value)
+        return "pending"
+    return s  # type: ignore[return-value]
+
+
+# --------------------------------------------------------------------------- #
+# Atomic JSON IO
+# --------------------------------------------------------------------------- #
+def _atomic_write_json(path: Path, payload: object) -> None:
+    """Write ``payload`` to ``path`` atomically (tempfile + rename)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=".tmp.", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, sort_keys=False)
+            f.write("\n")
+        os.replace(tmp_name, path)
+    except Exception:
+        # Best-effort cleanup if rename failed.
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# --------------------------------------------------------------------------- #
+# MappingStore
+# --------------------------------------------------------------------------- #
+@dataclass
+class MappingStore:
+    """
+    Manage the global color map (in ``config_path``) and per-illustration
+    overrides (in ``metadata_dir``).
+
+    All hex codes are stored canonical-uppercase (``#RRGGBB``).
+    """
+
+    config_path: Path
+    metadata_dir: Path
+
+    def __post_init__(self) -> None:
+        self.config_path = Path(self.config_path)
+        self.metadata_dir = Path(self.metadata_dir)
+
+    # ----- global map ------------------------------------------------------ #
+    def load_config_raw(self) -> dict[str, object]:
+        """Load the full ``config.json`` (or ``{}`` if it doesn't exist yet)."""
+        if not self.config_path.is_file():
+            return {}
+        return json.loads(self.config_path.read_text(encoding="utf-8"))
+
+    def load_global_map(self) -> dict[str, dict[str, str]]:
+        """Return the canonical-keyed global color map."""
+        raw = self.load_config_raw()
+        gm = raw.get("global_color_map", {}) or {}
+        return {
+            str(k).upper(): {
+                "target": str(v.get("target", "")).upper(),
+                "label": str(v.get("label", "")),
+                "notes": str(v.get("notes", "")),
+            }
+            for k, v in gm.items()
+        }
+
+    def save_global_map(self, mapping: dict[str, dict[str, str]]) -> None:
+        """Persist the global color map back into ``config.json`` in place."""
+        cleaned = {
+            str(k).upper(): {
+                "target": str(v.get("target", "")).upper(),
+                "label": str(v.get("label", "")),
+                "notes": str(v.get("notes", "")),
+            }
+            for k, v in mapping.items()
+        }
+        raw = self.load_config_raw()
+        raw["global_color_map"] = cleaned
+        _atomic_write_json(self.config_path, raw)
+
+    def upsert_global_entry(
+        self,
+        source_hex: str,
+        target_hex: str,
+        label: str = "",
+        notes: str = "",
+    ) -> None:
+        """Insert or update one global entry."""
+        gm = self.load_global_map()
+        gm[source_hex.upper()] = {
+            "target": target_hex.upper(),
+            "label": label,
+            "notes": notes,
+        }
+        self.save_global_map(gm)
+
+    def remove_global_entry(self, source_hex: str) -> bool:
+        gm = self.load_global_map()
+        if source_hex.upper() in gm:
+            del gm[source_hex.upper()]
+            self.save_global_map(gm)
+            return True
+        return False
+
+    # ----- per-illustration ------------------------------------------------ #
+    def metadata_path_for(self, svg_filename: str) -> Path:
+        """Return the metadata path for an illustration filename."""
+        # Strip directories — only the basename is meaningful.
+        base = Path(svg_filename).name
+        return self.metadata_dir / f"{base}.mapping.json"
+
+    def load_illustration(self, svg_filename: str) -> IllustrationMapping:
+        """
+        Load per-illustration mapping. If no metadata file exists yet,
+        return a fresh ``IllustrationMapping(status='pending')`` — does NOT
+        write anything to disk.
+        """
+        path = self.metadata_path_for(svg_filename)
+        base = Path(svg_filename).name
+        if not path.is_file():
+            return IllustrationMapping(filename=base)
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            log.error("Corrupt metadata at %s: %s. Returning empty mapping.", path, exc)
+            return IllustrationMapping(filename=base)
+        m = IllustrationMapping.from_dict(raw)
+        # Defensive: filename inside file should match what we asked for.
+        if m.filename != base:
+            log.warning("Metadata %s claims filename=%r, expected %r — using disk value.",
+                        path, m.filename, base)
+        return m
+
+    def save_illustration(self, mapping: IllustrationMapping) -> None:
+        """Persist a per-illustration mapping. Stamps ``updated_at``."""
+        if not mapping.filename:
+            raise ValueError("IllustrationMapping.filename must be set before saving.")
+        mapping.touch()
+        _atomic_write_json(self.metadata_path_for(mapping.filename), mapping.to_dict())
+
+    def delete_illustration(self, svg_filename: str) -> bool:
+        path = self.metadata_path_for(svg_filename)
+        if path.is_file():
+            path.unlink()
+            return True
+        return False
+
+    def all_illustrations(self) -> list[IllustrationMapping]:
+        """Load every per-illustration metadata file in ``metadata_dir``."""
+        if not self.metadata_dir.is_dir():
+            return []
+        out: list[IllustrationMapping] = []
+        for p in sorted(self.metadata_dir.glob("*.mapping.json")):
+            try:
+                raw = json.loads(p.read_text(encoding="utf-8"))
+                out.append(IllustrationMapping.from_dict(raw))
+            except (OSError, json.JSONDecodeError) as exc:
+                log.warning("Skipping unreadable metadata %s: %s", p, exc)
+        return out
+
+    # ----- cross-library history ------------------------------------------- #
+    def history(self) -> dict[str, dict[str, int]]:
+        """
+        Build cross-library mapping history.
+
+        Returns ``{source_hex: {target_hex: count}}`` — across all
+        per-illustration overrides AND the global map (which always
+        contributes count 1).
+        """
+        hist: dict[str, dict[str, int]] = {}
+
+        # Global map contributes 1 each.
+        for src, entry in self.load_global_map().items():
+            tgt = entry.get("target", "").upper()
+            if tgt:
+                hist.setdefault(src.upper(), {})[tgt] = hist.get(src.upper(), {}).get(tgt, 0) + 1
+
+        # Per-illustration overrides each contribute 1.
+        for m in self.all_illustrations():
+            for src, tgt in m.overrides.items():
+                hist.setdefault(src.upper(), {})[tgt.upper()] = (
+                    hist.get(src.upper(), {}).get(tgt.upper(), 0) + 1
+                )
+        return hist
+
+    def usage_counts(self) -> dict[str, int]:
+        """How many illustrations use each global-map source color."""
+        counts: dict[str, int] = {}
+        for m in self.all_illustrations():
+            for src in m.overrides:
+                counts[src.upper()] = counts.get(src.upper(), 0) + 1
+        return counts
+
+
+# --------------------------------------------------------------------------- #
+# Convenience helpers
+# --------------------------------------------------------------------------- #
+def merge_mappings(
+    global_map: dict[str, dict[str, str]],
+    overrides: dict[str, str],
+) -> dict[str, str]:
+    """
+    Flatten a global map plus per-illustration overrides into a single
+    ``source_hex -> target_hex`` dict suitable for the SVG writer.
+
+    Per-illustration overrides win on conflict.
+    """
+    out: dict[str, str] = {
+        k.upper(): v["target"].upper() for k, v in global_map.items() if v.get("target")
+    }
+    out.update({k.upper(): v.upper() for k, v in overrides.items()})
+    return out

--- a/illustration-color-edit/src/print_safety.py
+++ b/illustration-color-edit/src/print_safety.py
@@ -1,0 +1,102 @@
+"""
+Print-safety checks for grayscale targets.
+
+Output is destined for an uncoated book paper print run. Very light grays
+(say lighter than ``#EEEEEE``) tend to disappear or look like the paper
+itself. This module flags any target gray that's lighter than the
+configured threshold so the user can pick a darker value.
+
+Threshold is configurable in ``config.json`` under ``print_safety``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from .color_mapper import gray_value, hex_to_rgb, is_grayscale
+from .config import PrintSafetyConfig
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SafetyWarning:
+    """A single print-safety concern about one target color."""
+
+    target: str            # canonical #RRGGBB
+    sources: tuple[str, ...]   # source hexes that map to this target
+    reason: str
+    luminance: int         # 0..255
+
+    def __str__(self) -> str:
+        srcs = ", ".join(self.sources) if self.sources else "(unused)"
+        return f"{self.target} (luminance={self.luminance}) — {self.reason} (used by: {srcs})"
+
+
+def _luminance_threshold(threshold_hex: str) -> int:
+    """Convert ``#EEEEEE`` -> integer luminance for fast comparison."""
+    return gray_value(threshold_hex)
+
+
+def check_target(
+    target_hex: str,
+    config: PrintSafetyConfig,
+    sources: Optional[Iterable[str]] = None,
+) -> Optional[SafetyWarning]:
+    """
+    Return a :class:`SafetyWarning` if ``target_hex`` is unsafe for print,
+    else ``None``.
+
+    Currently flags two conditions:
+
+      * Luminance lighter than ``config.min_gray_value``.
+      * Target is not actually grayscale (R/G/B differ noticeably) — this
+        usually means the user picked a tinted color by mistake.
+    """
+    target = target_hex.upper()
+    lum = gray_value(target)
+    threshold = _luminance_threshold(config.min_gray_value)
+    src_tuple = tuple(s.upper() for s in (sources or ()))
+
+    if lum > threshold:
+        return SafetyWarning(
+            target=target,
+            sources=src_tuple,
+            reason=f"luminance {lum} is lighter than configured min {threshold} ({config.min_gray_value})",
+            luminance=lum,
+        )
+
+    if not is_grayscale(target, tolerance=4):
+        r, g, b = hex_to_rgb(target)
+        return SafetyWarning(
+            target=target,
+            sources=src_tuple,
+            reason=f"target is not grayscale (R={r}, G={g}, B={b}) — channels should match",
+            luminance=lum,
+        )
+
+    return None
+
+
+def check_mapping(
+    mapping: dict[str, str],
+    config: PrintSafetyConfig,
+) -> list[SafetyWarning]:
+    """
+    Run :func:`check_target` over every target in ``mapping``.
+
+    ``mapping`` is the flat ``source_hex -> target_hex`` form (i.e. the
+    output of :func:`mapping_store.merge_mappings`).
+    """
+    by_target: dict[str, list[str]] = {}
+    for src, tgt in mapping.items():
+        by_target.setdefault(tgt.upper(), []).append(src.upper())
+
+    warnings: list[SafetyWarning] = []
+    for target, sources in by_target.items():
+        w = check_target(target, config, sources=sources)
+        if w is not None:
+            warnings.append(w)
+    return warnings

--- a/illustration-color-edit/src/svg_parser.py
+++ b/illustration-color-edit/src/svg_parser.py
@@ -1,0 +1,351 @@
+"""
+SVG parsing and color extraction.
+
+Surfaces a single dataclass-driven API:
+
+    parse_svg(path | bytes | str) -> ParsedSVG
+
+    ParsedSVG.colors  -> dict[hex -> ColorUsage]   (canonical #RRGGBB uppercase)
+
+The parser walks every element and extracts color tokens from:
+
+  * ``fill`` / ``stroke`` / ``stop-color`` attributes
+  * inline ``style="..."`` CSS
+  * ``<style>`` blocks (CSS rules)
+
+It normalizes all forms to uppercase 6-digit hex:
+
+  * ``#f00`` -> ``#FF0000``
+  * ``red`` -> ``#FF0000``
+  * ``rgb(255, 0, 0)`` -> ``#FF0000``
+  * ``rgb(100%, 0%, 0%)`` -> ``#FF0000``
+
+Tokens that the SVG color spec treats as non-paint (``none``,
+``currentColor``, ``inherit``, ``transparent``, URL refs to gradients) are
+ignored — we don't try to remap them.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Optional, Union
+
+from lxml import etree
+
+log = logging.getLogger(__name__)
+
+
+# CSS Level 3/4 named colors (the subset SVG uses). Lowercased keys.
+# Source: https://www.w3.org/TR/css-color-4/#named-colors
+CSS_NAMED_COLORS: dict[str, str] = {
+    "aliceblue": "#F0F8FF", "antiquewhite": "#FAEBD7", "aqua": "#00FFFF",
+    "aquamarine": "#7FFFD4", "azure": "#F0FFFF", "beige": "#F5F5DC",
+    "bisque": "#FFE4C4", "black": "#000000", "blanchedalmond": "#FFEBCD",
+    "blue": "#0000FF", "blueviolet": "#8A2BE2", "brown": "#A52A2A",
+    "burlywood": "#DEB887", "cadetblue": "#5F9EA0", "chartreuse": "#7FFF00",
+    "chocolate": "#D2691E", "coral": "#FF7F50", "cornflowerblue": "#6495ED",
+    "cornsilk": "#FFF8DC", "crimson": "#DC143C", "cyan": "#00FFFF",
+    "darkblue": "#00008B", "darkcyan": "#008B8B", "darkgoldenrod": "#B8860B",
+    "darkgray": "#A9A9A9", "darkgreen": "#006400", "darkgrey": "#A9A9A9",
+    "darkkhaki": "#BDB76B", "darkmagenta": "#8B008B", "darkolivegreen": "#556B2F",
+    "darkorange": "#FF8C00", "darkorchid": "#9932CC", "darkred": "#8B0000",
+    "darksalmon": "#E9967A", "darkseagreen": "#8FBC8F", "darkslateblue": "#483D8B",
+    "darkslategray": "#2F4F4F", "darkslategrey": "#2F4F4F",
+    "darkturquoise": "#00CED1", "darkviolet": "#9400D3", "deeppink": "#FF1493",
+    "deepskyblue": "#00BFFF", "dimgray": "#696969", "dimgrey": "#696969",
+    "dodgerblue": "#1E90FF", "firebrick": "#B22222", "floralwhite": "#FFFAF0",
+    "forestgreen": "#228B22", "fuchsia": "#FF00FF", "gainsboro": "#DCDCDC",
+    "ghostwhite": "#F8F8FF", "gold": "#FFD700", "goldenrod": "#DAA520",
+    "gray": "#808080", "green": "#008000", "greenyellow": "#ADFF2F",
+    "grey": "#808080", "honeydew": "#F0FFF0", "hotpink": "#FF69B4",
+    "indianred": "#CD5C5C", "indigo": "#4B0082", "ivory": "#FFFFF0",
+    "khaki": "#F0E68C", "lavender": "#E6E6FA", "lavenderblush": "#FFF0F5",
+    "lawngreen": "#7CFC00", "lemonchiffon": "#FFFACD", "lightblue": "#ADD8E6",
+    "lightcoral": "#F08080", "lightcyan": "#E0FFFF",
+    "lightgoldenrodyellow": "#FAFAD2", "lightgray": "#D3D3D3",
+    "lightgreen": "#90EE90", "lightgrey": "#D3D3D3", "lightpink": "#FFB6C1",
+    "lightsalmon": "#FFA07A", "lightseagreen": "#20B2AA",
+    "lightskyblue": "#87CEFA", "lightslategray": "#778899",
+    "lightslategrey": "#778899", "lightsteelblue": "#B0C4DE",
+    "lightyellow": "#FFFFE0", "lime": "#00FF00", "limegreen": "#32CD32",
+    "linen": "#FAF0E6", "magenta": "#FF00FF", "maroon": "#800000",
+    "mediumaquamarine": "#66CDAA", "mediumblue": "#0000CD",
+    "mediumorchid": "#BA55D3", "mediumpurple": "#9370DB",
+    "mediumseagreen": "#3CB371", "mediumslateblue": "#7B68EE",
+    "mediumspringgreen": "#00FA9A", "mediumturquoise": "#48D1CC",
+    "mediumvioletred": "#C71585", "midnightblue": "#191970",
+    "mintcream": "#F5FFFA", "mistyrose": "#FFE4E1", "moccasin": "#FFE4B5",
+    "navajowhite": "#FFDEAD", "navy": "#000080", "oldlace": "#FDF5E6",
+    "olive": "#808000", "olivedrab": "#6B8E23", "orange": "#FFA500",
+    "orangered": "#FF4500", "orchid": "#DA70D6", "palegoldenrod": "#EEE8AA",
+    "palegreen": "#98FB98", "paleturquoise": "#AFEEEE",
+    "palevioletred": "#DB7093", "papayawhip": "#FFEFD5", "peachpuff": "#FFDAB9",
+    "peru": "#CD853F", "pink": "#FFC0CB", "plum": "#DDA0DD",
+    "powderblue": "#B0E0E6", "purple": "#800080", "rebeccapurple": "#663399",
+    "red": "#FF0000", "rosybrown": "#BC8F8F", "royalblue": "#4169E1",
+    "saddlebrown": "#8B4513", "salmon": "#FA8072", "sandybrown": "#F4A460",
+    "seagreen": "#2E8B57", "seashell": "#FFF5EE", "sienna": "#A0522D",
+    "silver": "#C0C0C0", "skyblue": "#87CEEB", "slateblue": "#6A5ACD",
+    "slategray": "#708090", "slategrey": "#708090", "snow": "#FFFAFA",
+    "springgreen": "#00FF7F", "steelblue": "#4682B4", "tan": "#D2B48C",
+    "teal": "#008080", "thistle": "#D8BFD8", "tomato": "#FF6347",
+    "turquoise": "#40E0D0", "violet": "#EE82EE", "wheat": "#F5DEB3",
+    "white": "#FFFFFF", "whitesmoke": "#F5F5F5", "yellow": "#FFFF00",
+    "yellowgreen": "#9ACD32",
+}
+
+# Tokens that SVG accepts as paint values but that are not concrete colors —
+# we leave them alone during extraction *and* mapping.
+NON_COLOR_TOKENS = frozenset({"none", "transparent", "currentcolor", "inherit", "initial", "unset"})
+
+# Attributes whose value is always a paint reference.
+PAINT_ATTRS = ("fill", "stroke", "stop-color", "flood-color", "lighting-color")
+
+# CSS properties whose value is a paint reference.
+CSS_PAINT_PROPS = frozenset({
+    "fill", "stroke", "stop-color", "flood-color", "lighting-color", "color",
+    "background", "background-color", "border-color",
+})
+
+_HEX_RE = re.compile(r"#([0-9a-fA-F]{3,8})\b")
+_RGB_RE = re.compile(
+    r"rgba?\(\s*"
+    r"(-?\d+(?:\.\d+)?%?)\s*,?\s*"
+    r"(-?\d+(?:\.\d+)?%?)\s*,?\s*"
+    r"(-?\d+(?:\.\d+)?%?)"
+    r"(?:\s*[,/]\s*-?\d+(?:\.\d+)?%?)?"  # alpha (ignored)
+    r"\s*\)",
+    re.IGNORECASE,
+)
+_NAMED_RE = re.compile(r"\b([a-zA-Z]{3,30})\b")
+
+
+@dataclass
+class ColorUsage:
+    """Tracks where a normalized color appears inside an SVG."""
+
+    hex: str  # canonical #RRGGBB uppercase
+    count: int = 0
+    contexts: set[str] = field(default_factory=set)
+    raw_forms: set[str] = field(default_factory=set)
+
+    def record(self, context: str, raw: str) -> None:
+        self.count += 1
+        self.contexts.add(context)
+        self.raw_forms.add(raw)
+
+
+@dataclass
+class ParsedSVG:
+    """Parsed SVG with extracted color usage. ``tree`` is the raw lxml tree."""
+
+    source: Optional[Path]
+    tree: etree._ElementTree
+    colors: dict[str, ColorUsage]
+    raw_bytes: bytes
+
+    @property
+    def unique_color_count(self) -> int:
+        return len(self.colors)
+
+
+# --------------------------------------------------------------------------- #
+# Normalization
+# --------------------------------------------------------------------------- #
+def normalize_hex(value: str) -> Optional[str]:
+    """
+    Normalize a single CSS/SVG color token to canonical ``#RRGGBB`` uppercase.
+
+    Returns ``None`` if the value is not a concrete color (``none``,
+    ``currentColor``, gradient URL, malformed input, etc.).
+    """
+    if not value:
+        return None
+    v = value.strip()
+    if not v:
+        return None
+    low = v.lower()
+    if low in NON_COLOR_TOKENS:
+        return None
+    if low.startswith("url("):
+        return None
+
+    # Hex
+    if v.startswith("#"):
+        body = v[1:]
+        if len(body) == 3 and all(c in "0123456789abcdefABCDEF" for c in body):
+            return "#" + "".join(ch * 2 for ch in body).upper()
+        if len(body) == 4 and all(c in "0123456789abcdefABCDEF" for c in body):
+            # #RGBA -> drop alpha, expand
+            return "#" + "".join(ch * 2 for ch in body[:3]).upper()
+        if len(body) == 6 and all(c in "0123456789abcdefABCDEF" for c in body):
+            return "#" + body.upper()
+        if len(body) == 8 and all(c in "0123456789abcdefABCDEF" for c in body):
+            return "#" + body[:6].upper()
+        return None
+
+    # rgb(...) / rgba(...)
+    m = _RGB_RE.fullmatch(v)
+    if m:
+        try:
+            channels = [_parse_channel(m.group(i)) for i in (1, 2, 3)]
+        except ValueError:
+            return None
+        return "#{:02X}{:02X}{:02X}".format(*channels)
+
+    # Named color
+    if low in CSS_NAMED_COLORS:
+        return CSS_NAMED_COLORS[low]
+
+    return None
+
+
+def _parse_channel(token: str) -> int:
+    token = token.strip()
+    if token.endswith("%"):
+        pct = float(token[:-1])
+        return max(0, min(255, round(pct * 255 / 100)))
+    val = float(token)
+    return max(0, min(255, round(val)))
+
+
+def iter_color_tokens(text: str) -> Iterable[tuple[str, str]]:
+    """
+    Yield ``(raw_token, normalized_hex)`` pairs found anywhere in ``text``.
+
+    Used both for inline ``style`` attributes and for ``<style>`` block
+    contents. We scan with regexes and normalize each match; tokens that
+    don't normalize (e.g. ``url(#grad1)``) are skipped.
+    """
+    seen_spans: set[tuple[int, int]] = set()
+
+    for m in _HEX_RE.finditer(text):
+        span = m.span()
+        seen_spans.add(span)
+        norm = normalize_hex(m.group(0))
+        if norm:
+            yield m.group(0), norm
+
+    for m in _RGB_RE.finditer(text):
+        seen_spans.add(m.span())
+        norm = normalize_hex(m.group(0))
+        if norm:
+            yield m.group(0), norm
+
+    for m in _NAMED_RE.finditer(text):
+        # Skip if this match overlaps with an already-consumed hex/rgb token
+        # (e.g. the "rgb" inside "rgb(...)").
+        s, e = m.span()
+        if any(not (e <= ss or s >= ee) for ss, ee in seen_spans):
+            continue
+        word = m.group(1).lower()
+        if word in CSS_NAMED_COLORS:
+            yield m.group(1), CSS_NAMED_COLORS[word]
+
+
+# --------------------------------------------------------------------------- #
+# Style attribute parsing
+# --------------------------------------------------------------------------- #
+_DECL_RE = re.compile(r"\s*([a-zA-Z-]+)\s*:\s*([^;]+?)\s*(?:;|$)")
+
+
+def parse_style_attribute(value: str) -> list[tuple[str, str]]:
+    """
+    Parse an inline ``style="prop: val; prop: val"`` attribute into a list of
+    ``(property, value)`` pairs, preserving order.
+    """
+    if not value:
+        return []
+    return [(m.group(1).strip().lower(), m.group(2).strip()) for m in _DECL_RE.finditer(value)]
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+SVG_NS = "http://www.w3.org/2000/svg"
+
+
+def _localname(tag: object) -> str:
+    """Return the local part of an etree tag (strip namespace)."""
+    if not isinstance(tag, str):
+        return ""
+    if "}" in tag:
+        return tag.split("}", 1)[1]
+    return tag
+
+
+def parse_svg(source: Union[str, Path, bytes]) -> ParsedSVG:
+    """
+    Parse an SVG and return a :class:`ParsedSVG`.
+
+    ``source`` may be a path-like, a raw bytes blob, or an SVG string.
+    """
+    raw: bytes
+    src_path: Optional[Path]
+    if isinstance(source, (str, Path)) and not (
+        isinstance(source, str) and source.lstrip().startswith("<")
+    ):
+        src_path = Path(source)
+        raw = src_path.read_bytes()
+    elif isinstance(source, bytes):
+        src_path = None
+        raw = source
+    else:
+        src_path = None
+        raw = source.encode("utf-8")  # type: ignore[union-attr]
+
+    parser = etree.XMLParser(remove_comments=False, recover=False, huge_tree=True)
+    try:
+        tree = etree.ElementTree(etree.fromstring(raw, parser=parser))
+    except etree.XMLSyntaxError as exc:
+        log.error("Malformed SVG (%s): %s", src_path, exc)
+        raise
+
+    colors: dict[str, ColorUsage] = {}
+
+    def _record(norm: str, context: str, raw_form: str) -> None:
+        cu = colors.setdefault(norm, ColorUsage(hex=norm))
+        cu.record(context, raw_form)
+
+    root = tree.getroot()
+    for el in root.iter():
+        local = _localname(el.tag)
+
+        # Paint attributes
+        for attr in PAINT_ATTRS:
+            val = el.get(attr)
+            if val is None:
+                continue
+            norm = normalize_hex(val)
+            if norm:
+                _record(norm, f"@{attr}", val)
+
+        # Inline style
+        style = el.get("style")
+        if style:
+            for prop, val in parse_style_attribute(style):
+                if prop in CSS_PAINT_PROPS:
+                    norm = normalize_hex(val)
+                    if norm:
+                        _record(norm, f"style.{prop}", val)
+                    else:
+                        # value may itself contain a token (e.g. "url(...) #fff")
+                        for raw_tok, n in iter_color_tokens(val):
+                            _record(n, f"style.{prop}", raw_tok)
+
+        # <style> blocks: scan their text content for any color tokens.
+        if local == "style":
+            text = "".join(el.itertext())
+            for raw_tok, norm in iter_color_tokens(text):
+                _record(norm, "style-block", raw_tok)
+
+    return ParsedSVG(source=src_path, tree=tree, colors=colors, raw_bytes=raw)
+
+
+def extract_unique_colors(source: Union[str, Path, bytes]) -> dict[str, int]:
+    """Convenience: return ``{normalized_hex: count}`` for an SVG."""
+    parsed = parse_svg(source)
+    return {h: u.count for h, u in parsed.colors.items()}

--- a/illustration-color-edit/src/svg_writer.py
+++ b/illustration-color-edit/src/svg_writer.py
@@ -1,0 +1,235 @@
+"""
+SVG writer — applies a color mapping to a parsed SVG.
+
+Strategy: re-walk the tree the parser produced, find color tokens in the
+same locations (paint attributes, inline ``style`` CSS, ``<style>`` block
+text), and substitute them in place. Everything else (paths, transforms,
+text, IDs, comments, namespaces) is left untouched so the round-trip back
+into Affinity Designer is clean.
+
+The mapping passed in is a flat dict of canonical ``#RRGGBB`` -> target
+``#RRGGBB``. Colors not in the mapping are left as-is (callers can decide
+to flag them; see :func:`apply_mapping_with_report`).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional, Union
+
+from lxml import etree
+
+from .svg_parser import (
+    CSS_PAINT_PROPS,
+    PAINT_ATTRS,
+    ParsedSVG,
+    _HEX_RE,
+    _NAMED_RE,
+    _RGB_RE,
+    _localname,
+    normalize_hex,
+    parse_style_attribute,
+    parse_svg,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class WriteReport:
+    """Summary returned by :func:`apply_mapping_with_report`."""
+
+    replacements: int = 0                              # total tokens rewritten
+    by_source: dict[str, int] = field(default_factory=dict)  # per-source-hex counts
+    unmapped: dict[str, int] = field(default_factory=dict)   # source hexes with no mapping
+
+    def record_replace(self, source_hex: str) -> None:
+        self.replacements += 1
+        self.by_source[source_hex] = self.by_source.get(source_hex, 0) + 1
+
+    def record_unmapped(self, source_hex: str) -> None:
+        self.unmapped[source_hex] = self.unmapped.get(source_hex, 0) + 1
+
+
+# --------------------------------------------------------------------------- #
+# Token-level replacement (used for inline-style values and <style> blocks)
+# --------------------------------------------------------------------------- #
+_COMBINED_RE = re.compile(
+    r"(rgba?\(\s*[^)]*\))"               # rgb(...) / rgba(...)
+    r"|(#[0-9a-fA-F]{3,8}\b)"            # hex
+    r"|\b([a-zA-Z]{3,30})\b",            # word (possibly a named color)
+)
+
+
+def replace_color_tokens(
+    text: str,
+    mapping: dict[str, str],
+    on_replace=None,
+    on_unmapped=None,
+) -> str:
+    """
+    Replace every concrete color token in ``text`` whose normalized form is a
+    key in ``mapping``. Tokens that don't normalize to a known color (e.g.
+    ``url(#g)``, the bare word ``fill``) are left alone.
+
+    Callbacks (optional) let the caller track replacements and unmapped
+    colors for reporting.
+    """
+    def _sub(m: re.Match) -> str:
+        token = m.group(0)
+        norm = normalize_hex(token)
+        if norm is None:
+            return token  # not a color we recognise — leave it alone
+        target = mapping.get(norm)
+        if target is None:
+            if on_unmapped is not None:
+                on_unmapped(norm)
+            return token
+        if on_replace is not None:
+            on_replace(norm)
+        return target
+    return _COMBINED_RE.sub(_sub, text)
+
+
+# --------------------------------------------------------------------------- #
+# Element-level rewriting
+# --------------------------------------------------------------------------- #
+def _rewrite_inline_style(
+    style_value: str,
+    mapping: dict[str, str],
+    report: WriteReport,
+) -> str:
+    """Rewrite an inline ``style="..."`` attribute, only touching paint props."""
+    decls = parse_style_attribute(style_value)
+    if not decls:
+        return style_value
+
+    out_parts: list[str] = []
+    for prop, val in decls:
+        if prop in CSS_PAINT_PROPS:
+            new_val = replace_color_tokens(
+                val,
+                mapping,
+                on_replace=report.record_replace,
+                on_unmapped=report.record_unmapped,
+            )
+            out_parts.append(f"{prop}: {new_val}")
+        else:
+            out_parts.append(f"{prop}: {val}")
+    return "; ".join(out_parts)
+
+
+def _rewrite_element(
+    el: etree._Element,
+    mapping: dict[str, str],
+    report: WriteReport,
+) -> None:
+    # Paint attributes
+    for attr in PAINT_ATTRS:
+        val = el.get(attr)
+        if val is None:
+            continue
+        norm = normalize_hex(val)
+        if norm is None:
+            continue
+        target = mapping.get(norm)
+        if target is None:
+            report.record_unmapped(norm)
+            continue
+        el.set(attr, target)
+        report.record_replace(norm)
+
+    # Inline style
+    style = el.get("style")
+    if style:
+        new_style = _rewrite_inline_style(style, mapping, report)
+        if new_style != style:
+            el.set("style", new_style)
+
+    # <style> block text
+    if _localname(el.tag) == "style":
+        if el.text:
+            new_text = replace_color_tokens(
+                el.text,
+                mapping,
+                on_replace=report.record_replace,
+                on_unmapped=report.record_unmapped,
+            )
+            if new_text != el.text:
+                el.text = new_text
+        # Some authoring tools wrap CSS in CDATA which lxml exposes as a child
+        # node; iterate child text just in case.
+        for child in el:
+            if child.text:
+                new_child_text = replace_color_tokens(
+                    child.text, mapping,
+                    on_replace=report.record_replace,
+                    on_unmapped=report.record_unmapped,
+                )
+                if new_child_text != child.text:
+                    child.text = new_child_text
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+def apply_mapping_with_report(
+    source: Union[ParsedSVG, str, Path, bytes],
+    mapping: dict[str, str],
+) -> tuple[bytes, WriteReport]:
+    """
+    Apply ``mapping`` (source_hex -> target_hex; canonical ``#RRGGBB``) to
+    ``source`` and return ``(svg_bytes, report)``.
+
+    ``source`` may be a :class:`ParsedSVG` (re-used to avoid re-parsing) or
+    anything :func:`parse_svg` accepts.
+    """
+    if isinstance(source, ParsedSVG):
+        # Operate on a deep copy so the input ParsedSVG stays clean.
+        tree = deepcopy(source.tree)
+    else:
+        tree = parse_svg(source).tree
+        tree = deepcopy(tree)
+
+    norm_mapping = {k.upper(): v.upper() for k, v in mapping.items()}
+    report = WriteReport()
+
+    root = tree.getroot()
+    for el in root.iter():
+        _rewrite_element(el, norm_mapping, report)
+
+    body = etree.tostring(tree, xml_declaration=True, encoding="utf-8", standalone=False)
+    return body, report
+
+
+def apply_mapping(
+    source: Union[ParsedSVG, str, Path, bytes],
+    mapping: dict[str, str],
+) -> bytes:
+    """Convenience wrapper around :func:`apply_mapping_with_report`."""
+    body, _ = apply_mapping_with_report(source, mapping)
+    return body
+
+
+def write_converted_svg(
+    source: Union[ParsedSVG, str, Path],
+    mapping: dict[str, str],
+    destination: Path,
+) -> WriteReport:
+    """
+    Apply ``mapping`` and write the result to ``destination``.
+
+    Creates parent directories. Returns a :class:`WriteReport` for logging.
+    """
+    body, report = apply_mapping_with_report(source, mapping)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(body)
+    log.info(
+        "Wrote %s (%d replacements, %d unmapped colors)",
+        destination, report.replacements, len(report.unmapped),
+    )
+    return report

--- a/illustration-color-edit/tests/test_color_mapper.py
+++ b/illustration-color-edit/tests/test_color_mapper.py
@@ -1,0 +1,198 @@
+"""Tests for src.color_mapper."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.color_mapper import (
+    ColorMapper,
+    MatchKind,
+    color_distance,
+    gray_value,
+    hex_to_lab,
+    hex_to_rgb,
+    is_grayscale,
+    rgb_to_hex,
+    suggest_from_history,
+)
+from src.config import MatchingConfig
+
+
+# --------------------------------------------------------------------------- #
+# Color-space helpers
+# --------------------------------------------------------------------------- #
+def test_hex_to_rgb_roundtrip():
+    assert hex_to_rgb("#FF0000") == (255, 0, 0)
+    assert rgb_to_hex((255, 0, 0)) == "#FF0000"
+    assert rgb_to_hex(hex_to_rgb("#ABCDEF")) == "#ABCDEF"
+
+
+def test_hex_to_lab_known_values():
+    # Pure black -> L=0, a=0, b=0
+    L, a, b = hex_to_lab("#000000")
+    assert L == pytest.approx(0.0, abs=1e-3)
+    assert a == pytest.approx(0.0, abs=1e-3)
+    assert b == pytest.approx(0.0, abs=1e-3)
+
+    # Pure white -> L=100
+    L, _, _ = hex_to_lab("#FFFFFF")
+    assert L == pytest.approx(100.0, abs=1e-3)
+
+
+def test_color_distance_lab_zero_for_identity():
+    assert color_distance("#FF0000", "#FF0000", "lab") == pytest.approx(0.0, abs=1e-9)
+
+
+def test_color_distance_close_reds():
+    # Two visually-close reds should be much nearer than red vs. green.
+    d_close = color_distance("#E74C3C", "#E63E3E", "lab")
+    d_far = color_distance("#E74C3C", "#2ECC71", "lab")
+    assert d_close < 10.0
+    assert d_far > 50.0
+
+
+def test_color_distance_rgb_metric():
+    d = color_distance("#000000", "#FFFFFF", "rgb")
+    assert d == pytest.approx(math.sqrt(3 * 255**2))
+
+
+def test_color_distance_unknown_metric_raises():
+    with pytest.raises(ValueError):
+        color_distance("#000000", "#FFFFFF", "weird")
+
+
+def test_is_grayscale():
+    assert is_grayscale("#808080")
+    assert is_grayscale("#7F8081")  # within tolerance
+    assert not is_grayscale("#FF0000")
+
+
+def test_gray_value():
+    assert gray_value("#000000") == 0
+    assert gray_value("#FFFFFF") == 255
+    # Pure red has lower luminance than pure green per Rec.709.
+    assert gray_value("#FF0000") < gray_value("#00FF00")
+
+
+# --------------------------------------------------------------------------- #
+# ColorMapper: suggest()
+# --------------------------------------------------------------------------- #
+GLOBAL_MAP = {
+    "#E74C3C": {"target": "#333333", "label": "red / bad", "notes": ""},
+    "#2ECC71": {"target": "#CCCCCC", "label": "green / good", "notes": ""},
+}
+
+
+def test_suggest_exact_match():
+    m = ColorMapper(global_map=GLOBAL_MAP, matching=MatchingConfig())
+    s = m.suggest("#E74C3C")
+    assert s.kind is MatchKind.EXACT
+    assert s.target == "#333333"
+    assert s.distance == 0.0
+
+
+def test_suggest_exact_is_case_insensitive():
+    m = ColorMapper(global_map=GLOBAL_MAP, matching=MatchingConfig())
+    assert m.suggest("#e74c3c").target == "#333333"
+
+
+def test_suggest_near_match_within_threshold():
+    m = ColorMapper(
+        global_map=GLOBAL_MAP,
+        matching=MatchingConfig(nearest_enabled=True, metric="lab", threshold=15.0),
+    )
+    s = m.suggest("#E63E3E")  # close to #E74C3C
+    assert s.kind is MatchKind.NEAR
+    assert s.target == "#333333"
+    assert s.via == "#E74C3C"
+    assert 0 < s.distance < 15.0
+
+
+def test_suggest_near_disabled_falls_through_to_none():
+    m = ColorMapper(
+        global_map=GLOBAL_MAP,
+        matching=MatchingConfig(nearest_enabled=False, metric="lab", threshold=999.0),
+    )
+    s = m.suggest("#E63E3E")
+    assert s.kind is MatchKind.NONE
+    assert s.target is None
+
+
+def test_suggest_no_match_when_threshold_too_tight():
+    m = ColorMapper(
+        global_map=GLOBAL_MAP,
+        matching=MatchingConfig(nearest_enabled=True, metric="lab", threshold=0.1),
+    )
+    s = m.suggest("#0000FF")
+    assert s.kind is MatchKind.NONE
+
+
+def test_suggest_picks_closest_when_multiple_in_range():
+    big_map = {
+        "#FF0000": {"target": "#111111", "label": "red"},
+        "#00FF00": {"target": "#222222", "label": "green"},
+        "#0000FF": {"target": "#333333", "label": "blue"},
+    }
+    m = ColorMapper(
+        global_map=big_map,
+        matching=MatchingConfig(nearest_enabled=True, metric="lab", threshold=999.0),
+    )
+    s = m.suggest("#0000F0")  # closest to blue
+    assert s.via == "#0000FF"
+    assert s.target == "#333333"
+
+
+def test_overrides_take_priority_over_global():
+    m = ColorMapper(global_map=GLOBAL_MAP, matching=MatchingConfig())
+    over = m.with_overrides({"#E74C3C": "#999999"})
+    s = over.suggest("#E74C3C")
+    assert s.kind is MatchKind.EXACT
+    assert s.target == "#999999"
+
+    # Original mapper untouched.
+    assert m.suggest("#E74C3C").target == "#333333"
+
+
+# --------------------------------------------------------------------------- #
+# Resolve / apply_to_palette
+# --------------------------------------------------------------------------- #
+def test_resolve_with_manual_override():
+    m = ColorMapper(global_map=GLOBAL_MAP)
+    assert m.resolve("#E74C3C", manual="#abcdef") == "#ABCDEF"
+
+
+def test_resolve_invalid_manual_raises():
+    m = ColorMapper(global_map=GLOBAL_MAP)
+    with pytest.raises(ValueError):
+        m.resolve("#E74C3C", manual="not-a-color")
+
+
+def test_apply_to_palette_returns_full_dict_with_unmapped_as_none():
+    m = ColorMapper(
+        global_map=GLOBAL_MAP,
+        matching=MatchingConfig(nearest_enabled=False),
+    )
+    result = m.apply_to_palette(["#E74C3C", "#123456"])
+    assert result["#E74C3C"] == "#333333"
+    assert result["#123456"] is None
+
+
+def test_apply_to_palette_honors_manual_overrides():
+    m = ColorMapper(global_map=GLOBAL_MAP)
+    result = m.apply_to_palette(["#E74C3C"], manual={"#E74C3C": "#000000"})
+    assert result["#E74C3C"] == "#000000"
+
+
+# --------------------------------------------------------------------------- #
+# History suggestions
+# --------------------------------------------------------------------------- #
+def test_suggest_from_history_sorts_by_count_desc():
+    history = {"#E74C3C": {"#222222": 1, "#333333": 4, "#111111": 2}}
+    out = suggest_from_history("#e74c3c", history)
+    assert out == [("#333333", 4), ("#111111", 2), ("#222222", 1)]
+
+
+def test_suggest_from_history_empty_returns_empty():
+    assert suggest_from_history("#FF0000", {}) == []

--- a/illustration-color-edit/tests/test_mapping_store.py
+++ b/illustration-color-edit/tests/test_mapping_store.py
@@ -1,0 +1,199 @@
+"""Tests for src.mapping_store."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.mapping_store import (
+    IllustrationMapping,
+    MappingStore,
+    VALID_STATUSES,
+    merge_mappings,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def store(tmp_path):
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({
+        "global_color_map": {
+            "#E74C3C": {"target": "#333333", "label": "red / bad", "notes": ""},
+        },
+        "matching": {"nearest_enabled": True, "metric": "lab", "threshold": 10.0},
+        "paths": {"input_dir": "./input", "output_dir": "./output", "metadata_dir": "./metadata"},
+    }), encoding="utf-8")
+    meta = tmp_path / "metadata"
+    meta.mkdir()
+    return MappingStore(config_path=cfg, metadata_dir=meta)
+
+
+# --------------------------------------------------------------------------- #
+# IllustrationMapping
+# --------------------------------------------------------------------------- #
+def test_illustration_mapping_roundtrip():
+    m = IllustrationMapping(
+        filename="x.svg",
+        status="reviewed",
+        overrides={"#ff0000": "#222222"},
+        notes="hello",
+    )
+    d = m.to_dict()
+    assert d["overrides"] == {"#FF0000": "#222222"}  # normalized
+    m2 = IllustrationMapping.from_dict(d)
+    assert m2.filename == "x.svg"
+    assert m2.status == "reviewed"
+    assert m2.overrides == {"#FF0000": "#222222"}
+
+
+def test_illustration_mapping_with_status_validates():
+    m = IllustrationMapping(filename="x.svg")
+    m.with_status("reviewed")
+    assert m.status == "reviewed"
+    assert m.updated_at  # timestamp set
+    with pytest.raises(ValueError):
+        m.with_status("garbage")  # type: ignore[arg-type]
+
+
+def test_illustration_mapping_unknown_status_coerces_to_pending():
+    m = IllustrationMapping.from_dict({"filename": "x.svg", "status": "weird"})
+    assert m.status == "pending"
+
+
+# --------------------------------------------------------------------------- #
+# Global map IO
+# --------------------------------------------------------------------------- #
+def test_load_global_map_returns_canonical_keys(store):
+    gm = store.load_global_map()
+    assert "#E74C3C" in gm
+    assert gm["#E74C3C"]["target"] == "#333333"
+
+
+def test_save_global_map_preserves_other_config_sections(store):
+    store.save_global_map({"#FF0000": {"target": "#111111", "label": "x", "notes": ""}})
+    raw = json.loads(store.config_path.read_text(encoding="utf-8"))
+    assert "matching" in raw  # untouched
+    assert raw["global_color_map"] == {
+        "#FF0000": {"target": "#111111", "label": "x", "notes": ""}
+    }
+
+
+def test_upsert_and_remove_global_entry(store):
+    store.upsert_global_entry("#aabbcc", "#222222", label="lbl", notes="nts")
+    gm = store.load_global_map()
+    assert gm["#AABBCC"]["target"] == "#222222"
+    assert gm["#AABBCC"]["label"] == "lbl"
+
+    assert store.remove_global_entry("#AABBCC") is True
+    assert "#AABBCC" not in store.load_global_map()
+    # Removing a non-existent entry is a no-op.
+    assert store.remove_global_entry("#AABBCC") is False
+
+
+# --------------------------------------------------------------------------- #
+# Per-illustration IO
+# --------------------------------------------------------------------------- #
+def test_load_illustration_returns_pending_when_missing(store):
+    m = store.load_illustration("nope.svg")
+    assert m.status == "pending"
+    assert m.overrides == {}
+    # Should not have written anything to disk.
+    assert not store.metadata_path_for("nope.svg").exists()
+
+
+def test_save_then_load_illustration(store):
+    m = IllustrationMapping(filename="figure-01.svg")
+    m.overrides = {"#E74C3C": "#333333"}
+    m.with_status("reviewed")
+    store.save_illustration(m)
+
+    again = store.load_illustration("figure-01.svg")
+    assert again.status == "reviewed"
+    assert again.overrides == {"#E74C3C": "#333333"}
+    assert again.updated_at == m.updated_at
+
+
+def test_save_illustration_uses_basename_only(store):
+    m = IllustrationMapping(filename="subdir/x.svg", overrides={"#FF0000": "#000000"})
+    m.filename = "x.svg"  # caller passes basename
+    store.save_illustration(m)
+
+    # The on-disk file is at metadata/<base>.mapping.json
+    assert (store.metadata_dir / "x.svg.mapping.json").exists()
+
+
+def test_delete_illustration(store):
+    m = IllustrationMapping(filename="x.svg")
+    store.save_illustration(m)
+    assert store.delete_illustration("x.svg") is True
+    assert store.delete_illustration("x.svg") is False
+
+
+def test_load_illustration_handles_corrupt_metadata(store, caplog):
+    p = store.metadata_path_for("bad.svg")
+    p.write_text("not-json{", encoding="utf-8")
+    m = store.load_illustration("bad.svg")
+    assert m.status == "pending"
+    assert m.overrides == {}
+
+
+# --------------------------------------------------------------------------- #
+# all_illustrations + history
+# --------------------------------------------------------------------------- #
+def _save(store, name, overrides):
+    m = IllustrationMapping(filename=name, overrides=overrides)
+    store.save_illustration(m)
+
+
+def test_all_illustrations_lists_metadata_files(store):
+    _save(store, "a.svg", {"#FF0000": "#111111"})
+    _save(store, "b.svg", {"#00FF00": "#222222"})
+    out = sorted(m.filename for m in store.all_illustrations())
+    assert out == ["a.svg", "b.svg"]
+
+
+def test_history_aggregates_across_illustrations_and_global(store):
+    _save(store, "a.svg", {"#FF0000": "#111111"})
+    _save(store, "b.svg", {"#FF0000": "#111111"})
+    _save(store, "c.svg", {"#FF0000": "#222222"})
+
+    hist = store.history()
+    # Global map contributes its #E74C3C->#333333.
+    assert hist["#E74C3C"] == {"#333333": 1}
+    # Three illustrations: two map red to #111111, one to #222222.
+    assert hist["#FF0000"] == {"#111111": 2, "#222222": 1}
+
+
+def test_history_used_by_suggest_from_history(store):
+    from src.color_mapper import suggest_from_history
+    _save(store, "a.svg", {"#FF0000": "#111111"})
+    _save(store, "b.svg", {"#FF0000": "#111111"})
+    out = suggest_from_history("#FF0000", store.history())
+    assert out[0] == ("#111111", 2)
+
+
+# --------------------------------------------------------------------------- #
+# merge_mappings
+# --------------------------------------------------------------------------- #
+def test_merge_mappings_overrides_win():
+    gm = {
+        "#FF0000": {"target": "#111111", "label": "r"},
+        "#00FF00": {"target": "#222222", "label": "g"},
+    }
+    over = {"#ff0000": "#999999"}
+    merged = merge_mappings(gm, over)
+    assert merged["#FF0000"] == "#999999"
+    assert merged["#00FF00"] == "#222222"
+
+
+def test_merge_mappings_skips_global_entries_without_target():
+    gm = {"#FF0000": {"target": "", "label": ""}}
+    assert merge_mappings(gm, {}) == {}
+
+
+def test_valid_statuses_constant_matches_literal():
+    assert set(VALID_STATUSES) == {"pending", "in_progress", "reviewed", "exported"}

--- a/illustration-color-edit/tests/test_print_safety.py
+++ b/illustration-color-edit/tests/test_print_safety.py
@@ -1,0 +1,37 @@
+"""Smoke tests for src.print_safety."""
+
+from __future__ import annotations
+
+from src.config import PrintSafetyConfig
+from src.print_safety import check_mapping, check_target
+
+
+def test_check_target_safe_returns_none():
+    cfg = PrintSafetyConfig(min_gray_value="#EEEEEE", warn_only=True)
+    assert check_target("#333333", cfg) is None
+
+
+def test_check_target_too_light_warns():
+    cfg = PrintSafetyConfig(min_gray_value="#EEEEEE")
+    w = check_target("#F5F5F5", cfg)
+    assert w is not None
+    assert "lighter" in w.reason
+
+
+def test_check_target_non_gray_warns():
+    cfg = PrintSafetyConfig(min_gray_value="#EEEEEE")
+    w = check_target("#444433", cfg, sources=["#FF0000"])
+    assert w is not None
+    assert "not grayscale" in w.reason
+    assert w.sources == ("#FF0000",)
+
+
+def test_check_mapping_groups_sources_by_target():
+    cfg = PrintSafetyConfig(min_gray_value="#EEEEEE")
+    mapping = {"#FF0000": "#FAFAFA", "#00FF00": "#FAFAFA", "#0000FF": "#222222"}
+    warnings = check_mapping(mapping, cfg)
+    # Only #FAFAFA should warn.
+    assert len(warnings) == 1
+    w = warnings[0]
+    assert w.target == "#FAFAFA"
+    assert set(w.sources) == {"#FF0000", "#00FF00"}

--- a/illustration-color-edit/tests/test_svg_parser.py
+++ b/illustration-color-edit/tests/test_svg_parser.py
@@ -1,0 +1,187 @@
+"""Tests for src.svg_parser."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from src.svg_parser import (
+    extract_unique_colors,
+    iter_color_tokens,
+    normalize_hex,
+    parse_style_attribute,
+    parse_svg,
+)
+
+
+# --------------------------------------------------------------------------- #
+# normalize_hex
+# --------------------------------------------------------------------------- #
+class TestNormalizeHex:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("#FF0000", "#FF0000"),
+            ("#ff0000", "#FF0000"),
+            ("#F00", "#FF0000"),
+            ("#f00", "#FF0000"),
+            ("#FF0000FF", "#FF0000"),  # 8-digit hex with alpha -> drop alpha
+            ("#F00A", "#FF0000"),       # 4-digit hex with alpha
+            ("rgb(255, 0, 0)", "#FF0000"),
+            ("rgb(255,0,0)", "#FF0000"),
+            ("rgb( 255 , 0 , 0 )", "#FF0000"),
+            ("rgba(255, 0, 0, 0.5)", "#FF0000"),
+            ("rgb(100%, 0%, 0%)", "#FF0000"),
+            ("red", "#FF0000"),
+            ("Red", "#FF0000"),
+            ("CORNFLOWERBLUE", "#6495ED"),
+        ],
+    )
+    def test_valid_forms_normalize(self, raw, expected):
+        assert normalize_hex(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "  ",
+            "none",
+            "transparent",
+            "currentColor",
+            "inherit",
+            "url(#grad1)",
+            "notacolor",
+            "#GG0000",
+            "#12",
+            "#1234567890",
+        ],
+    )
+    def test_invalid_or_non_color_returns_none(self, raw):
+        assert normalize_hex(raw) is None
+
+
+# --------------------------------------------------------------------------- #
+# parse_style_attribute
+# --------------------------------------------------------------------------- #
+def test_parse_style_attribute_basic():
+    out = parse_style_attribute("fill: #ff0000; stroke:#00FF00;opacity:.5")
+    assert out == [("fill", "#ff0000"), ("stroke", "#00FF00"), ("opacity", ".5")]
+
+
+def test_parse_style_attribute_empty():
+    assert parse_style_attribute("") == []
+    assert parse_style_attribute(";;;") == []
+
+
+# --------------------------------------------------------------------------- #
+# iter_color_tokens
+# --------------------------------------------------------------------------- #
+def test_iter_color_tokens_in_css_block():
+    css = """
+    .a { fill: #ff0000; }
+    .b { stroke: rgb(0, 255, 0); }
+    .c { fill: cornflowerblue; background: #abc; }
+    """
+    found = {norm for _, norm in iter_color_tokens(css)}
+    assert {"#FF0000", "#00FF00", "#6495ED", "#AABBCC"}.issubset(found)
+
+
+def test_iter_color_tokens_does_not_match_words_inside_rgb():
+    # "rgb" is itself a 3-letter word; ensure we don't double-count it as a name.
+    raw = "rgb(0, 0, 0)"
+    pairs = list(iter_color_tokens(raw))
+    norms = [n for _, n in pairs]
+    assert norms == ["#000000"]
+
+
+def test_iter_color_tokens_skips_arbitrary_words():
+    raw = "fill is set to #FF0000 here"
+    norms = [n for _, n in iter_color_tokens(raw)]
+    # 'fill', 'is', 'set', 'to', 'here' are not named colors -> skipped
+    assert norms == ["#FF0000"]
+
+
+# --------------------------------------------------------------------------- #
+# parse_svg integration
+# --------------------------------------------------------------------------- #
+INLINE_SVG = """<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="0" y="0" width="50" height="50" fill="#E74C3C" stroke="#333"/>
+  <circle cx="60" cy="60" r="10" style="fill: rgb(46, 204, 113); stroke:#F00"/>
+  <text x="10" y="90" fill="cornflowerblue">label</text>
+</svg>"""
+
+
+def test_parse_svg_inline_attributes_and_style():
+    parsed = parse_svg(INLINE_SVG)
+    assert "#E74C3C" in parsed.colors
+    assert "#333333" in parsed.colors                  # 3-digit expanded
+    assert "#2ECC71" in parsed.colors                  # rgb() normalized
+    assert "#FF0000" in parsed.colors                  # #F00 expanded
+    assert "#6495ED" in parsed.colors                  # named
+    # Counts
+    assert parsed.colors["#E74C3C"].count == 1
+    # Contexts
+    assert "@fill" in parsed.colors["#E74C3C"].contexts
+
+
+STYLE_BLOCK_SVG = """<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <style type="text/css"><![CDATA[
+    .bad  { fill: #E74C3C; }
+    .good { fill: rgb(46, 204, 113); stroke: cornflowerblue; }
+  ]]></style>
+  <rect class="bad" x="0" y="0" width="10" height="10"/>
+  <rect class="good" x="20" y="0" width="10" height="10"/>
+</svg>"""
+
+
+def test_parse_svg_style_block_extraction():
+    parsed = parse_svg(STYLE_BLOCK_SVG)
+    assert "#E74C3C" in parsed.colors
+    assert "#2ECC71" in parsed.colors
+    assert "#6495ED" in parsed.colors
+    assert any("style-block" in u.contexts for u in parsed.colors.values())
+
+
+GRADIENT_SVG = """<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g">
+      <stop offset="0" stop-color="#ABCDEF"/>
+      <stop offset="1" stop-color="rgb(0%, 50%, 100%)"/>
+    </linearGradient>
+  </defs>
+  <rect fill="url(#g)" stroke="none" width="10" height="10"/>
+</svg>"""
+
+
+def test_parse_svg_gradient_stops_extracted_url_ignored():
+    parsed = parse_svg(GRADIENT_SVG)
+    assert "#ABCDEF" in parsed.colors
+    assert "#0080FF" in parsed.colors
+    # url(#g) and 'none' should NOT produce entries.
+    assert "URL(#G)" not in parsed.colors
+    assert "NONE" not in parsed.colors
+
+
+def test_parse_svg_malformed_raises():
+    with pytest.raises(Exception):
+        parse_svg("<svg><not-closed>")
+
+
+def test_extract_unique_colors_returns_counts():
+    counts = extract_unique_colors(INLINE_SVG)
+    assert counts["#E74C3C"] == 1
+
+
+def test_parse_svg_from_bytes_and_path(tmp_path):
+    p = tmp_path / "x.svg"
+    p.write_text(INLINE_SVG, encoding="utf-8")
+
+    a = parse_svg(p)
+    b = parse_svg(p.read_bytes())
+    c = parse_svg(INLINE_SVG)
+
+    assert set(a.colors) == set(b.colors) == set(c.colors)

--- a/illustration-color-edit/tests/test_svg_writer.py
+++ b/illustration-color-edit/tests/test_svg_writer.py
@@ -1,0 +1,153 @@
+"""Tests for src.svg_writer."""
+
+from __future__ import annotations
+
+import re
+
+from src.svg_parser import extract_unique_colors, parse_svg
+from src.svg_writer import apply_mapping, apply_mapping_with_report, write_converted_svg
+
+
+INLINE_SVG = """<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="0" y="0" width="50" height="50" fill="#E74C3C" stroke="#333"/>
+  <circle cx="60" cy="60" r="10" style="fill: rgb(46, 204, 113); stroke:#F00"/>
+  <text x="10" y="90" fill="cornflowerblue">label</text>
+</svg>"""
+
+
+STYLE_BLOCK_SVG = """<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .bad  { fill: #E74C3C; }
+    .good { fill: rgb(46, 204, 113); stroke: cornflowerblue; }
+  </style>
+  <rect class="bad" width="10" height="10"/>
+  <rect class="good" width="10" height="10"/>
+</svg>"""
+
+
+GRADIENT_SVG = """<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g">
+      <stop offset="0" stop-color="#ABCDEF"/>
+      <stop offset="1" stop-color="rgb(0%, 50%, 100%)"/>
+    </linearGradient>
+  </defs>
+  <rect fill="url(#g)" width="10" height="10"/>
+</svg>"""
+
+
+def test_apply_mapping_replaces_inline_attributes():
+    mapping = {"#E74C3C": "#333333", "#333333": "#222222"}
+    out = apply_mapping(INLINE_SVG, mapping).decode("utf-8")
+    # The fill="#E74C3C" became "#333333"; stroke="#333" (which normalizes to
+    # #333333) became "#222222".
+    assert 'fill="#333333"' in out
+    assert 'stroke="#222222"' in out
+
+
+def test_apply_mapping_replaces_style_attribute_paint_props():
+    mapping = {"#2ECC71": "#CCCCCC", "#FF0000": "#444444"}
+    out = apply_mapping(INLINE_SVG, mapping).decode("utf-8")
+    # rgb(...) was inside style — it's now the target hex
+    assert "#CCCCCC" in out
+    # named "red" via #F00 in style was mapped
+    assert "#444444" in out
+    # original tokens are gone
+    assert "rgb(46, 204, 113)" not in out
+    assert "#F00" not in out
+
+
+def test_apply_mapping_replaces_style_block_text():
+    mapping = {
+        "#E74C3C": "#333333",
+        "#2ECC71": "#CCCCCC",
+        "#6495ED": "#888888",  # cornflowerblue
+    }
+    out = apply_mapping(STYLE_BLOCK_SVG, mapping).decode("utf-8")
+    assert "#333333" in out
+    assert "#CCCCCC" in out
+    assert "#888888" in out
+    # Original named color is gone (replaced).
+    assert "cornflowerblue" not in out
+    # rgb(...) is gone (replaced).
+    assert "rgb(46, 204, 113)" not in out
+
+
+def test_apply_mapping_named_color_replaced_inline_attribute():
+    svg = '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg">' \
+          '<rect fill="cornflowerblue" width="1" height="1"/></svg>'
+    out = apply_mapping(svg, {"#6495ED": "#444444"}).decode("utf-8")
+    assert 'fill="#444444"' in out
+    assert "cornflowerblue" not in out
+
+
+def test_apply_mapping_leaves_unmapped_colors_unchanged():
+    mapping = {"#E74C3C": "#333333"}  # only the red is mapped
+    out = apply_mapping(INLINE_SVG, mapping).decode("utf-8")
+    # Unmapped green should still be present somewhere
+    assert "rgb(46, 204, 113)" in out
+
+
+def test_apply_mapping_report_counts_replacements_and_unmapped():
+    mapping = {"#E74C3C": "#333333"}
+    _, report = apply_mapping_with_report(INLINE_SVG, mapping)
+    assert report.replacements >= 1
+    assert report.by_source["#E74C3C"] >= 1
+    # Other colors present in the SVG but not in mapping should appear in
+    # the unmapped report.
+    assert "#2ECC71" in report.unmapped
+    assert "#FF0000" in report.unmapped
+    assert "#6495ED" in report.unmapped
+    assert "#333333" in report.unmapped
+
+
+def test_apply_mapping_preserves_paths_and_ids():
+    svg = """<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <path id="thing-42" d="M0 0 L 10 10 Z" fill="#FF0000"/>
+</svg>"""
+    out = apply_mapping(svg, {"#FF0000": "#222222"}).decode("utf-8")
+    assert 'id="thing-42"' in out
+    assert 'd="M0 0 L 10 10 Z"' in out
+    assert 'fill="#222222"' in out
+
+
+def test_apply_mapping_preserves_gradient_url_reference():
+    out = apply_mapping(GRADIENT_SVG, {"#ABCDEF": "#111111"}).decode("utf-8")
+    # The url(#g) reference must still be intact.
+    assert 'fill="url(#g)"' in out
+    # The stop-color was rewritten.
+    assert "#111111" in out
+
+
+def test_apply_mapping_does_not_mutate_input_parsed_svg():
+    parsed = parse_svg(INLINE_SVG)
+    before = set(parsed.colors)
+    apply_mapping(parsed, {"#E74C3C": "#333333"})
+    after = extract_unique_colors(parsed.raw_bytes)
+    # parsed.tree gets re-used by callers; ensure we copied it.
+    assert before == set(after.keys()) | (set() if before == set(after.keys()) else set())
+
+
+def test_write_converted_svg_creates_file(tmp_path):
+    src = tmp_path / "in.svg"
+    src.write_text(INLINE_SVG, encoding="utf-8")
+    dst = tmp_path / "out" / "out.svg"
+
+    report = write_converted_svg(src, {"#E74C3C": "#333333"}, dst)
+    assert dst.exists()
+    text = dst.read_text(encoding="utf-8")
+    assert "#333333" in text
+    assert report.replacements >= 1
+
+
+def test_idempotent_with_empty_mapping():
+    out = apply_mapping(INLINE_SVG, {}).decode("utf-8")
+    # Strip xml declaration line for comparison; lxml may add encoding.
+    assert "rect" in out
+    assert "circle" in out
+    # All original colors still present (in some normalized form).
+    assert "#E74C3C" in out or "#e74c3c" in out


### PR DESCRIPTION
## Summary

This PR introduces a complete industrial-grade SVG color-to-grayscale conversion pipeline for book illustrations. The system consists of a Streamlit interactive editor for per-illustration color mapping and a CLI batch processor for converting entire libraries once mappings are finalized.

## Key Changes

### Core Pipeline (`src/`)
- **svg_parser.py**: Extracts colors from SVG elements, inline styles, and `<style>` blocks. Normalizes all color formats (hex, rgb, named colors) to canonical uppercase `#RRGGBB`.
- **color_mapper.py**: Implements color matching engine with three strategies:
  - Exact match against global color map
  - Nearest-neighbor matching using CIE Lab ΔE or RGB Euclidean distance
  - Manual assignment for unmapped colors
  - Includes color space conversions (sRGB → XYZ → Lab) and grayscale detection
- **svg_writer.py**: Applies color mappings back to SVG by rewriting paint attributes, inline styles, and `<style>` blocks while preserving all other SVG structure
- **mapping_store.py**: Persistence layer for global color map (in `config.json`) and per-illustration overrides (in `metadata/*.mapping.json`). Computes cross-library history of color mappings.
- **library_manager.py**: Scans input directory and joins SVG metadata with mapping status
- **print_safety.py**: Validates target grayscale values against luminance thresholds for uncoated paper printing
- **config.py**: Configuration loader with fallback to example config on fresh checkout
- **cli.py**: Batch CLI with subcommands for status reporting, inspection, and bulk conversion

### Streamlit UI (`app/`)
- **app.py**: Main entry point with tab routing and session state initialization
- **tab_library.py**: Browse SVGs with status badges and quick navigation
- **tab_editor.py**: Side-by-side preview with per-color mapping, suggestion engine, and print-safety warnings
- **tab_global_map.py**: View and manage project-wide color mappings
- **tab_batch.py**: Batch export reviewed or all illustrations to output directory
- **tab_settings.py**: Read-only config viewer
- **common.py**: Shared UI helpers (color swatches, caching, SVG rendering)

### Testing & Configuration
- Comprehensive pytest test suite covering color space math, parsing, mapping logic, and persistence
- `config.json.example`: Template with sensible defaults
- `requirements.txt`: Streamlit, lxml, pytest dependencies
- `launch_app.bat`: Windows convenience launcher
- `.gitignore`: Excludes secrets, venv, working directories

## Notable Implementation Details

- **Color normalization**: Handles 3/6/8-digit hex, rgb/rgba percentages, and 147 CSS named colors per W3C spec
- **Non-paint tokens**: Correctly ignores `none`, `currentColor`, `inherit`, `transparent`, and gradient URL references
- **Atomic JSON I/O**: Uses tempfile + rename pattern for crash-safe persistence
- **CIE Lab color distance**: Implements proper sRGB gamma correction and D65 reference white for perceptually-accurate nearest-color matching
- **SVG round-trip**: Preserves all non-color SVG structure (paths, transforms, IDs, namespaces) for clean re-import into Affinity Designer
- **Status workflow**: Tracks per-illustration state (pending → in_progress → reviewed → exported) with timestamps
- **History tracking**: Aggregates how each source color was mapped across the entire library to surface reuse suggestions

https://claude.ai/code/session_01PPYg9HDJQTCmrLufdZ3Mfs