### PR TITLE
feat(system): markdown_preview — tray-resident GitHub-style markdown viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The master template lives in [`project-scaffolding/docs/agents/`](../project-sca
 - **`copy_git_project.py`** - Git project copying and setup
 - **`base64_encode_decode.py`** - Base64 encode/decode utility
 - **`word_to_markdown.py`** - Word to Markdown conversion
+- **`markdown_preview.py`** - Tray-resident GitHub-style Markdown previewer (Edge WebView2) with light/dark toggle and live reload — see [`system/markdown_preview.md`](system/markdown_preview.md)
 - **`foldersearcher/`**, **`treesize/`** - Folder search and size utilities
 
 ### 📝 Text Processing (`text/`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -164,6 +164,12 @@ keyboard>=0.13.5
 win10toast>=0.9
 pywin32>=306
 
+# Markdown preview tray app (renders via Edge WebView2)
+# Source: system/markdown_preview.py
+pywebview>=5.0
+markdown>=3.5
+Pygments>=2.17
+
 # =============================================================================
 # NETWORKING AND WEB
 # =============================================================================

--- a/system/markdown_preview.bat
+++ b/system/markdown_preview.bat
@@ -1,0 +1,7 @@
+@echo off
+REM Launch Markdown Preview silently into the system tray using the project venv.
+REM Optional first argument: a .md file to open on launch.
+set "SCRIPT_DIR=%~dp0"
+set "REPO_ROOT=%SCRIPT_DIR%.."
+start "" /B "%REPO_ROOT%\.venv\Scripts\pythonw.exe" "%SCRIPT_DIR%markdown_preview.py" %*
+exit

--- a/system/markdown_preview.md
+++ b/system/markdown_preview.md
@@ -1,0 +1,58 @@
+# Markdown Preview
+
+A self-contained, tray-resident Markdown previewer. It renders a `.md` file as GitHub-style HTML inside an Edge WebView2 window (via [pywebview](https://pywebview.flowrl.com/)), with a per-window light/dark toggle. Built for locked-down machines where installing a Markdown viewer (Typora, MarkText, Obsidian, …) is blocked — it runs as plain Python through the project's `.venv`, so there is no extra executable to install.
+
+## Features
+
+- **System Tray App**: runs in the system tray; click the icon to open the window, close the window to hide it back to the tray, Quit from the tray menu. Single-instance — launching it twice just shows a message and exits.
+- **GitHub-style rendering**: headings, tables, fenced code with syntax highlighting (Pygments), blockquotes, images. Styling mirrors GitHub's light/dark color tokens.
+- **Light/dark toggle**: a button in the top toolbar flips the theme instantly. New windows default to the current **Windows app theme**.
+- **Live reload**: the open file is watched on disk; saving it from your editor refreshes the preview within ~1 second.
+- **Open any file**: pass a path on launch, or pick one from the tray's **Open file…** dialog. Opening a different file reloads the same window.
+
+## Requirements
+
+- Python 3
+- `pywebview`, `markdown`, `Pygments`, `pystray`, `Pillow`
+- Windows with the **Edge WebView2 runtime** (preinstalled on Windows 11). If absent, install the Microsoft Evergreen WebView2 runtime (per-user install, no admin needed).
+
+Install from the project requirements:
+
+```
+pip install -r ../../requirements.txt
+```
+
+## Usage
+
+Launch silently into the tray (no console window) via the `.bat`:
+
+```
+markdown_preview.bat
+markdown_preview.bat path\to\file.md
+```
+
+Or run directly:
+
+```
+pythonw markdown_preview.py [path\to\file.md]
+```
+
+Without a file argument the window shows a short placeholder until you pick a file from **Open file…**.
+
+### Wiring to "Open with…"
+
+Because the `.bat` forwards its first argument to the script, you can set it as a Windows "Open with…" handler for `.md` files (point the association at `markdown_preview.bat`).
+
+## Tray menu
+
+- **Open** — show / raise the window (default action; also the icon click).
+- **Open file…** — pick a `.md` and load it into the window.
+- **Quit** — exit the app and release the single-instance lock.
+
+## How it works
+
+1. A single-instance lock is taken by binding a fixed `127.0.0.1` port; a second launch detects the bound port, shows a message box, and exits.
+2. The Markdown is converted to HTML in Python (`markdown` + `Pygments`) and wrapped in an embedded, offline GitHub-style stylesheet (both light and dark variants).
+3. The HTML is displayed in a pywebview window backed by Edge WebView2. The light/dark toggle flips a `data-theme` attribute via JavaScript; the choice is mirrored back to Python so it survives a live-reload re-render.
+4. pywebview's GUI loop owns the main thread; the pystray tray icon and the file watcher each run on a background thread.
+5. The window's close event is intercepted to **hide** the window instead of destroying it, so the process stays in the tray. **Quit** destroys the window, which ends the loop and releases the lock.

--- a/system/markdown_preview.py
+++ b/system/markdown_preview.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""
+markdown_preview.py
+
+A self-contained, tray-resident markdown previewer. Renders a Markdown file as
+GitHub-style HTML inside an Edge WebView2 window (via pywebview), with a
+per-window light/dark toggle that defaults to the current Windows app theme.
+
+Runs from the system tray. Closing the window hides it back to the tray
+(the process stays alive); reopen it from the tray menu. Opening a different
+file reloads the same window. The open file is watched for changes on disk and
+the preview re-renders within ~1s of a save. Quit only from the tray menu.
+
+UI (tray menu):
+  * Open        - show / raise the window (default action)
+  * Open file...- pick a .md and load it into the window
+  * Quit        - exit the app
+
+Requirements:
+    pip install pywebview markdown Pygments pystray Pillow
+
+Usage:
+    pythonw markdown_preview.py [path\\to\\file.md]
+"""
+
+import argparse
+import ctypes
+import logging
+import threading
+import time
+from ctypes import wintypes
+from pathlib import Path
+from typing import Optional
+
+import markdown as md
+import pystray
+import webview
+from PIL import Image, ImageDraw
+from pygments.formatters import HtmlFormatter
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+MARKDOWN_EXTENSIONS = ["fenced_code", "tables", "toc", "codehilite", "sane_lists"]
+
+
+def detect_windows_theme() -> str:
+    """Return 'dark' or 'light' from the Windows 'apps' theme setting."""
+    try:
+        import winreg
+
+        key = winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER,
+            r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
+        )
+        apps_use_light, _ = winreg.QueryValueEx(key, "AppsUseLightTheme")
+        winreg.CloseKey(key)
+        return "light" if apps_use_light else "dark"
+    except OSError:
+        return "light"
+
+
+def _pygments_css() -> str:
+    """Syntax-highlighting CSS for both themes, scoped by data-theme."""
+    light = HtmlFormatter(style="default").get_style_defs(
+        '[data-theme="light"] .codehilite'
+    )
+    dark = HtmlFormatter(style="monokai").get_style_defs(
+        '[data-theme="dark"] .codehilite'
+    )
+    return light + "\n" + dark
+
+
+# GitHub-flavored CSS. Colors mirror GitHub's light/dark tokens; selectors are
+# driven by the data-theme attribute on <html> so the toggle is pure CSS.
+_BASE_CSS = """
+:root {
+  --bg: #ffffff; --fg: #1f2328; --muted: #59636e; --border: #d1d9e0;
+  --code-bg: #f6f8fa; --quote-fg: #59636e; --link: #0969da;
+  --table-alt: #f6f8fa; --hr: #d1d9e0;
+}
+[data-theme="dark"] {
+  --bg: #0d1117; --fg: #e6edf3; --muted: #9198a1; --border: #3d444d;
+  --code-bg: #151b23; --quote-fg: #9198a1; --link: #4493f8;
+  --table-alt: #151b23; --hr: #3d444d;
+}
+html, body { margin: 0; padding: 0; background: var(--bg); color: var(--fg); }
+* { box-sizing: border-box; }
+.toolbar {
+  position: sticky; top: 0; z-index: 10;
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 16px; background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  font: 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+.toolbar .fname { color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.toolbar button {
+  cursor: pointer; border: 1px solid var(--border); background: var(--code-bg);
+  color: var(--fg); border-radius: 6px; padding: 3px 10px; font-size: 13px; line-height: 1.4;
+}
+.toolbar button:hover { border-color: var(--muted); }
+.markdown-body {
+  max-width: 980px; margin: 0 auto; padding: 24px 32px 64px;
+  font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+  word-wrap: break-word;
+}
+.markdown-body h1, .markdown-body h2 { border-bottom: 1px solid var(--border); padding-bottom: .3em; }
+.markdown-body h1 { font-size: 2em; margin: .67em 0; }
+.markdown-body h2 { font-size: 1.5em; margin-top: 24px; }
+.markdown-body h3 { font-size: 1.25em; margin-top: 24px; }
+.markdown-body h4, .markdown-body h5, .markdown-body h6 { margin-top: 24px; }
+.markdown-body p, .markdown-body ul, .markdown-body ol, .markdown-body blockquote, .markdown-body table { margin-top: 0; margin-bottom: 16px; }
+.markdown-body a { color: var(--link); text-decoration: none; }
+.markdown-body a:hover { text-decoration: underline; }
+.markdown-body code {
+  background: var(--code-bg); border-radius: 6px; padding: .2em .4em;
+  font: 85% ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", monospace;
+}
+.markdown-body pre {
+  background: var(--code-bg); border-radius: 6px; padding: 16px;
+  overflow: auto; line-height: 1.45;
+}
+.markdown-body pre code { background: transparent; padding: 0; font-size: 85%; }
+.markdown-body .codehilite { background: var(--code-bg); border-radius: 6px; margin-bottom: 16px; }
+.markdown-body .codehilite pre { margin: 0; background: transparent; }
+.markdown-body blockquote {
+  color: var(--quote-fg); border-left: .25em solid var(--border);
+  padding: 0 1em; margin-left: 0;
+}
+.markdown-body table { border-collapse: collapse; display: block; width: max-content; max-width: 100%; overflow: auto; }
+.markdown-body table th, .markdown-body table td { border: 1px solid var(--border); padding: 6px 13px; }
+.markdown-body table tr:nth-child(2n) { background: var(--table-alt); }
+.markdown-body img { max-width: 100%; }
+.markdown-body hr { height: .25em; background: var(--hr); border: 0; margin: 24px 0; }
+.markdown-body ul, .markdown-body ol { padding-left: 2em; }
+"""
+
+# Built once: the stylesheet is constant across renders.
+_FULL_CSS = _BASE_CSS + _pygments_css()
+
+_PAGE_TEMPLATE = """<!DOCTYPE html>
+<html lang="en" data-theme="{theme}">
+<head>
+<meta charset="utf-8">
+<style>{css}</style>
+</head>
+<body>
+<div class="toolbar">
+  <button id="theme-btn" onclick="toggleTheme()" title="Toggle light/dark">{glyph}</button>
+  <span class="fname">{fname}</span>
+</div>
+<article class="markdown-body">{body}</article>
+<script>
+function applyGlyph() {{
+  var t = document.documentElement.getAttribute('data-theme');
+  document.getElementById('theme-btn').textContent = (t === 'dark') ? '\\u2600' : '\\u263d';
+}}
+function toggleTheme() {{
+  var el = document.documentElement;
+  var next = (el.getAttribute('data-theme') === 'dark') ? 'light' : 'dark';
+  el.setAttribute('data-theme', next);
+  applyGlyph();
+  if (window.pywebview && window.pywebview.api && window.pywebview.api.set_theme) {{
+    window.pywebview.api.set_theme(next);
+  }}
+}}
+applyGlyph();
+</script>
+</body>
+</html>"""
+
+
+class Api:
+    """Exposed to JS so the window's theme survives a live-reload re-render."""
+
+    def __init__(self, theme: str):
+        self.theme = theme
+
+    def set_theme(self, theme: str) -> None:
+        self.theme = theme
+
+
+class MarkdownPreviewApp:
+    _ICON_SIZE = 64
+    # Single-instance via a Windows named mutex (a fixed TCP-port lock is
+    # unreliable here — high ports fall in Windows' reserved/excluded ranges).
+    _MUTEX_NAME = "markdown_preview_singleton_v1"
+    _ERROR_ALREADY_EXISTS = 183
+
+    def __init__(self, initial_file: Optional[Path]):
+        self.current_file: Optional[Path] = initial_file
+        self._last_mtime: Optional[float] = None
+        self.api = Api(detect_windows_theme())
+
+        self.window: Optional[webview.Window] = None
+        self._quitting = False
+        self._mutex: Optional[int] = None
+
+        self._icon = pystray.Icon(
+            "markdown_preview",
+            self._make_icon(),
+            "Markdown Preview",
+            pystray.Menu(
+                pystray.MenuItem("Open", self._on_open, default=True),
+                pystray.MenuItem("Open file…", self._on_open_file),
+                pystray.Menu.SEPARATOR,
+                pystray.MenuItem("Quit", self._on_quit),
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def _render(self) -> str:
+        theme = self.api.theme
+        glyph = "☀" if theme == "dark" else "☽"
+        if self.current_file and self.current_file.is_file():
+            try:
+                text = self.current_file.read_text(encoding="utf-8")
+            except OSError as exc:
+                body = f"<h1>Cannot read file</h1><p>{exc}</p>"
+                fname = self.current_file.name
+            else:
+                body = md.markdown(text, extensions=MARKDOWN_EXTENSIONS)
+                fname = str(self.current_file)
+        else:
+            body = (
+                "<h1>Markdown Preview</h1>"
+                "<p>Open a <code>.md</code> file from the tray menu "
+                "(<strong>Open file…</strong>).</p>"
+            )
+            fname = "No file"
+        return _PAGE_TEMPLATE.format(
+            theme=theme,
+            css=_FULL_CSS,
+            glyph=glyph,
+            fname=fname,
+            body=body,
+        )
+
+    def _load_current(self) -> None:
+        if self.window is None:
+            return
+        self._last_mtime = self._file_mtime()
+        self.window.load_html(self._render())
+
+    def _file_mtime(self) -> Optional[float]:
+        if self.current_file and self.current_file.is_file():
+            try:
+                return self.current_file.stat().st_mtime
+            except OSError:
+                return None
+        return None
+
+    # ------------------------------------------------------------------
+    # Tray icon
+    # ------------------------------------------------------------------
+
+    def _make_icon(self) -> Image.Image:
+        """Draw a small document icon with a down-arrow (markdown glyph)."""
+        size = self._ICON_SIZE
+        img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+        draw = ImageDraw.Draw(img)
+        paper = (255, 255, 255)
+        edge = (55, 65, 81)
+        accent = (96, 165, 250)
+        # page with a folded corner
+        draw.polygon(
+            [(14, 6), (42, 6), (52, 16), (52, 58), (14, 58)],
+            fill=paper,
+            outline=edge,
+        )
+        draw.line([(42, 6), (42, 16), (52, 16)], fill=edge, width=2)
+        # down arrow (the "markdown" cue)
+        draw.line([(33, 24), (33, 44)], fill=accent, width=4)
+        draw.polygon([(25, 38), (41, 38), (33, 50)], fill=accent)
+        return img
+
+    def _on_open(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        if self.window is not None:
+            self.window.show()
+
+    def _on_open_file(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        if self.window is None:
+            return
+        result = self.window.create_file_dialog(
+            webview.OPEN_DIALOG,
+            allow_multiple=False,
+            file_types=("Markdown (*.md;*.markdown;*.mdown)", "All files (*.*)"),
+        )
+        if not result:
+            return
+        self.current_file = Path(result[0])
+        self._load_current()
+        self.window.show()
+
+    def _on_quit(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        logger.info("Shutting down Markdown Preview")
+        self._quitting = True
+        if self.window is not None:
+            self.window.destroy()
+        else:
+            icon.stop()
+
+    # ------------------------------------------------------------------
+    # Window lifecycle
+    # ------------------------------------------------------------------
+
+    def _on_closing(self) -> bool:
+        """Close button hides to tray; only Quit actually destroys."""
+        if self._quitting:
+            return True
+        if self.window is not None:
+            self.window.hide()
+        return False
+
+    def _watch_file(self) -> None:
+        """Poll the open file's mtime and re-render on change."""
+        while not self._quitting:
+            time.sleep(0.7)
+            if self.window is None or self.current_file is None:
+                continue
+            mtime = self._file_mtime()
+            if mtime is not None and mtime != self._last_mtime:
+                self._last_mtime = mtime
+                self.window.load_html(self._render())
+
+    # ------------------------------------------------------------------
+    # Single-instance lock
+    # ------------------------------------------------------------------
+
+    def _acquire_lock(self) -> bool:
+        """Take a process-wide named mutex; False if another instance holds it.
+
+        The mutex is freed automatically when this process exits, so no
+        explicit release is needed.
+        """
+        k = ctypes.windll.kernel32
+        k.CreateMutexW.restype = wintypes.HANDLE
+        k.CreateMutexW.argtypes = [wintypes.LPVOID, wintypes.BOOL, wintypes.LPCWSTR]
+        self._mutex = k.CreateMutexW(None, True, self._MUTEX_NAME)
+        return k.GetLastError() != self._ERROR_ALREADY_EXISTS
+
+    # ------------------------------------------------------------------
+    # Run
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        if not self._acquire_lock():
+            ctypes.windll.user32.MessageBoxW(
+                0, "Markdown Preview is already running.", "Markdown Preview", 0x40
+            )
+            return
+
+        logger.info("Starting Markdown Preview (tray)")
+        self.window = webview.create_window(
+            "Markdown Preview",
+            html=self._render(),
+            js_api=self.api,
+            width=1000,
+            height=820,
+            text_select=True,
+        )
+        self.window.events.closing += self._on_closing
+        self._last_mtime = self._file_mtime()
+
+        threading.Thread(target=self._icon.run, daemon=True).start()
+        threading.Thread(target=self._watch_file, daemon=True).start()
+
+        webview.start(gui="edgechromium")
+
+        # start() returns once the window is destroyed (Quit)
+        self._quitting = True
+        try:
+            self._icon.stop()
+        except Exception:
+            pass
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Tray-resident GitHub-style markdown previewer.")
+    p.add_argument("file", nargs="?", default=None, help="Path to a .md file to open on launch")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    initial = Path(args.file).expanduser() if args.file else None
+    MarkdownPreviewApp(initial).run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `system/markdown_preview.py`, a self-contained tray-resident Markdown previewer for locked-down machines where installing a Markdown viewer is blocked. It renders a `.md` file as GitHub-style HTML inside an Edge WebView2 window (via pywebview), runs through the project `.venv` (no extra executable to install), and stays in the tray when the window is closed.

- One process, one tray icon, one window. Closing the window hides it to the tray; **Quit** exits.
- GitHub-style rendering (`markdown` + `Pygments`) with both light and dark stylesheets embedded offline.
- Per-window light/dark toggle (pure JS); new windows default to the current **Windows app theme**.
- Live reload: the open file's mtime is watched and the preview re-renders on save (~1s).
- Optional `.md` path as a CLI arg (wireable to "Open with…"); **Open file…** in the tray switches files.
- Single-instance via a Windows **named mutex** — a fixed high TCP port (the usual pattern in this repo) is unreliable here because Windows reserves large high-port ranges (`netsh int ipv4 show excludedportrange` showed 50160–50259 excluded, so a `bind()` fails with WinError 10013 regardless of whether another instance is running).

## Validation

Run on Windows 11, WebView2 runtime 148.x present.

- `py_compile system/markdown_preview.py` — OK.
- Headless render unit checks (`_render`): h1, tables, fenced-code highlighting, Pygments token classes, blockquote, nested list, image tag, `data-theme` propagation, toolbar/toggle present, filename, theme-toggle reflected, no-file placeholder — **all pass**.
- Behavioural (real app, screenshots captured):
  - Dark render (default, matched Windows dark theme): headings, bordered table with alternating rows, syntax-highlighted Python, blockquote bar, nested list — correct.
  - Light/dark toggle clicked live → window flipped to light, glyph switched ☀→☽ — correct.
  - Live reload: edited the open file → H1 updated with no relaunch; theme persisted across the re-render.
  - Close-to-tray: WM_CLOSE → window hidden, process still alive.
  - Single-instance: verified via the named-mutex (`ALREADY_RUNNING` on the 2nd concurrent instance) **and** through the real `.bat` launcher (2nd launch opened no 2nd window, only the "already running" message box).
  - No console window: `.bat` launches via `pythonw.exe`.

No CI is configured in this repo, so there are no checks to wait on.

Note (out of scope here): `mouse_mover.py` uses port 50218, which is inside the same reserved range — its socket-based single-instance lock is likely also broken on this machine. Worth a follow-up.

Closes #18