### PR TITLE
chore: hoist load_config/load_excel_data into common/loaders.py

### DIFF
--- a/linkedin/profiles_data_extractor/common/__init__.py
+++ b/linkedin/profiles_data_extractor/common/__init__.py
@@ -1,3 +1,7 @@
 """
 Common utilities for LinkedIn profile data extraction.
 """
+
+from loaders import load_config, load_excel_data
+
+__all__ = ["load_config", "load_excel_data"]

--- a/linkedin/profiles_data_extractor/common/dashboard.py
+++ b/linkedin/profiles_data_extractor/common/dashboard.py
@@ -1,55 +1,11 @@
-import json
-import os
-from pathlib import Path
-
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
 
+from loaders import load_config, load_excel_data  # noqa: F401 — re-exported for callers
+
 # Page config is now handled in main.py
-
-def load_config():
-    """Load configuration from the JSON file in the same directory."""
-    config_path = Path(__file__).parent / "linkedin_profiles_data.json"
-    if not config_path.exists():
-        st.error(f"Config file not found at {config_path}")
-        return None
-    
-    try:
-        with open(config_path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception as e:
-        st.error(f"Error loading config: {e}")
-        return None
-
-def load_data(file_path):
-    """Load data from the Excel file."""
-    if not os.path.exists(file_path):
-        st.error(f"Data file not found at: {file_path}")
-        return None
-    
-    try:
-        # Load Excel file
-        df = pd.read_excel(file_path)
-        
-        # Ensure date columns are datetime
-        if 'date_contacted' in df.columns:
-            df['date_contacted'] = pd.to_datetime(df['date_contacted'], errors='coerce')
-
-        if 'date_connected' in df.columns:
-            df['date_connected'] = pd.to_datetime(df['date_connected'], errors='coerce')
-        
-        if 'date_revocation' in df.columns:
-            df['date_revocation'] = pd.to_datetime(df['date_revocation'], errors='coerce')
-        
-        if 'date_discarded' in df.columns:
-            df['date_discarded'] = pd.to_datetime(df['date_discarded'], errors='coerce')
-            
-        return df
-    except Exception as e:
-        st.error(f"Error loading Excel file: {e}")
-        return None
 
 def create_performance_chart(df_filtered, df_all, group_col):
     if group_col not in df_filtered.columns or group_col not in df_all.columns:

--- a/linkedin/profiles_data_extractor/common/dataentry.py
+++ b/linkedin/profiles_data_extractor/common/dataentry.py
@@ -1,6 +1,4 @@
-import json
 import logging
-import os
 from pathlib import Path
 from datetime import datetime
 import re
@@ -14,42 +12,7 @@ import streamlit as st
 # Import Excel formatting functions
 from excel_format_manager import convert_url_columns_to_hyperlinks, apply_format_from_json
 from history_manager import log_history
-
-def load_config():
-    """Load configuration from the JSON file in the same directory."""
-    config_path = Path(__file__).parent / "linkedin_profiles_data.json"
-    if not config_path.exists():
-        st.error(f"Config file not found at {config_path}")
-        return None
-
-    try:
-        with open(config_path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception as e:
-        st.error(f"Error loading config: {e}")
-        return None
-
-def load_excel_data(file_path):
-    """Load data from the Excel file."""
-    if not os.path.exists(file_path):
-        st.error(f"Data file not found at: {file_path}")
-        return None
-
-    try:
-        df = pd.read_excel(file_path)
-
-        # Ensure date columns are datetime
-        date_columns = ['date_contacted', 'date_connected', 'date_revocation', 'date_discarded']
-        for col in date_columns:
-            if col not in df.columns:
-                df[col] = pd.NaT  # Create missing column
-            if col in df.columns:
-                df[col] = pd.to_datetime(df[col], errors='coerce')
-
-        return df
-    except Exception as e:
-        st.error(f"Error loading Excel file: {e}")
-        return None
+from loaders import load_config, load_excel_data
 
 def save_to_excel(df, file_path):
     """Save DataFrame to Excel file."""

--- a/linkedin/profiles_data_extractor/common/history.py
+++ b/linkedin/profiles_data_extractor/common/history.py
@@ -1,26 +1,11 @@
-import json
 import os
-from pathlib import Path
 import pandas as pd
 import streamlit as st
 import openpyxl
 
 # Import history manager functions
 from history_manager import get_history_file_path
-
-def load_config():
-    """Load configuration from the JSON file in the same directory."""
-    config_path = Path(__file__).parent / "linkedin_profiles_data.json"
-    if not config_path.exists():
-        st.error(f"Config file not found at {config_path}")
-        return None
-
-    try:
-        with open(config_path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception as e:
-        st.error(f"Error loading config: {e}")
-        return None
+from loaders import load_config
 
 def load_history_data():
     """Load history data from the history Excel file."""

--- a/linkedin/profiles_data_extractor/common/loaders.py
+++ b/linkedin/profiles_data_extractor/common/loaders.py
@@ -1,0 +1,58 @@
+"""
+Shared I/O helpers for the LinkedIn profiles data extractor.
+
+All Streamlit pages inside this package import ``load_config`` and
+``load_excel_data`` from here so the loading logic lives in exactly one place.
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import streamlit as st
+
+
+def load_config() -> Optional[dict]:
+    """Load configuration from the JSON file in the same directory.
+
+    Returns the parsed JSON dict, or ``None`` on any error (displays
+    ``st.error`` in the Streamlit UI before returning).
+    """
+    config_path = Path(__file__).parent / "linkedin_profiles_data.json"
+    if not config_path.exists():
+        st.error(f"Config file not found at {config_path}")
+        return None
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as e:
+        st.error(f"Error loading config: {e}")
+        return None
+
+
+def load_excel_data(file_path: str) -> Optional[pd.DataFrame]:
+    """Load data from an Excel file and normalise all date columns to datetime.
+
+    Creates any missing expected date columns as ``pd.NaT`` so callers can
+    always assume those columns exist.  Returns ``None`` on any error.
+    """
+    if not os.path.exists(file_path):
+        st.error(f"Data file not found at: {file_path}")
+        return None
+
+    try:
+        df = pd.read_excel(file_path)
+
+        date_columns = ["date_contacted", "date_connected", "date_revocation", "date_discarded"]
+        for col in date_columns:
+            if col not in df.columns:
+                df[col] = pd.NaT
+            df[col] = pd.to_datetime(df[col], errors="coerce")
+
+        return df
+    except Exception as e:
+        st.error(f"Error loading Excel file: {e}")
+        return None

--- a/linkedin/profiles_data_extractor/common/main.py
+++ b/linkedin/profiles_data_extractor/common/main.py
@@ -1,8 +1,6 @@
 import streamlit as st
 from pathlib import Path
 import sys
-import os
-import json
 import pandas as pd
 
 # Add the current directory to Python path to import local modules
@@ -14,42 +12,7 @@ from dataentry import main as dataentry_main
 from reachout import main as reachout_main
 from extract_data import main as extract_data_main
 from history import main as history_main
-
-def load_config():
-    """Load configuration from the JSON file in the same directory."""
-    config_path = Path(__file__).parent / "linkedin_profiles_data.json"
-    if not config_path.exists():
-        st.error(f"Config file not found at {config_path}")
-        return None
-
-    try:
-        with open(config_path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception as e:
-        st.error(f"Error loading config: {e}")
-        return None
-
-def load_excel_data(file_path):
-    """Load data from the Excel file."""
-    if not os.path.exists(file_path):
-        st.error(f"Data file not found at: {file_path}")
-        return None
-
-    try:
-        df = pd.read_excel(file_path)
-
-        # Ensure date columns are datetime
-        date_columns = ['date_contacted', 'date_connected', 'date_revocation']
-        for col in date_columns:
-            if col not in df.columns:
-                df[col] = pd.NaT  # Create missing column
-            if col in df.columns:
-                df[col] = pd.to_datetime(df[col], errors='coerce')
-
-        return df
-    except Exception as e:
-        st.error(f"Error loading Excel file: {e}")
-        return None
+from loaders import load_config, load_excel_data
 
 def get_current_theme_mode():
     """Determine if the current theme is light or dark based on config.toml."""

--- a/linkedin/profiles_data_extractor/common/reachout.py
+++ b/linkedin/profiles_data_extractor/common/reachout.py
@@ -1,6 +1,4 @@
-import json
 import logging
-import os
 from pathlib import Path
 from datetime import datetime
 import re
@@ -15,6 +13,7 @@ import plotly.express as px
 # Import Excel formatting functions
 from excel_format_manager import convert_url_columns_to_hyperlinks, apply_format_from_json
 from history_manager import log_history
+from loaders import load_config, load_excel_data
 
 def generate_color_gradient(start_hex, end_hex, n):
     """Generate a gradient of n colors between start_hex and end_hex."""
@@ -166,41 +165,6 @@ def fuzzy_search_profiles(df, search_query, max_results=100):
     else:
         return df.head(0)
 
-def load_config():
-    """Load configuration from the JSON file in the same directory."""
-    config_path = Path(__file__).parent / "linkedin_profiles_data.json"
-    if not config_path.exists():
-        st.error(f"Config file not found at {config_path}")
-        return None
-
-    try:
-        with open(config_path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception as e:
-        st.error(f"Error loading config: {e}")
-        return None
-
-def load_excel_data(file_path):
-    """Load data from the Excel file."""
-    if not os.path.exists(file_path):
-        st.error(f"Data file not found at: {file_path}")
-        return None
-
-    try:
-        df = pd.read_excel(file_path)
-
-        # Ensure date columns are datetime
-        date_columns = ['date_contacted', 'date_connected', 'date_revocation', 'date_discarded']
-        for col in date_columns:
-            if col not in df.columns:
-                df[col] = pd.NaT  # Create missing column
-            if col in df.columns:
-                df[col] = pd.to_datetime(df[col], errors='coerce')
-
-        return df
-    except Exception as e:
-        st.error(f"Error loading Excel file: {e}")
-        return None
 
 def save_to_excel(df, file_path):
     """Save DataFrame to Excel file."""


### PR DESCRIPTION
## Summary

- Create `common/loaders.py` with a single canonical `load_config()` and `load_excel_data()`, typed with `Optional[...]` return values and normalising all four date columns (`date_contacted`, `date_connected`, `date_revocation`, `date_discarded`)
- Update `common/__init__.py` to re-export both helpers so package-level imports work
- Remove 6 byte-for-byte duplicate `load_config()` definitions from `dashboard.py`, `dataentry.py`, `history.py`, `main.py`, and `reachout.py`
- Remove 3 duplicate `load_excel_data()`/`load_data()` definitions from `dataentry.py`, `main.py`, and `reachout.py`; `dashboard.py`'s `load_data` only appeared in the deleted local def (the page receives data as a parameter)
- Drop now-unused `json`/`os` imports from modules that only used them in the removed loader bodies

`history_manager.py`'s `load_config` is intentionally kept separate — it is a non-Streamlit background module that logs via `logger.error`, not `st.error`, making it semantically distinct.

## Validation

- **Syntax gate:** `py -m py_compile` on all 7 changed files — all OK
- **No project tests exist** (confirmed by search; CLAUDE.md acknowledges this case)
- **Import resolution:** `from loaders import load_config, load_excel_data` verified via AST probe with `sys.path` matching `main.py`'s runtime path
- **Duplicate removal confirmed:** AST scan of all 5 consumer modules shows zero remaining definitions of `load_config`, `load_excel_data`, or `load_data`
- **Diff scope:** 7 files (6 modified + 1 created), 175 lines deleted, 68 added — nothing outside the stated scope

Closes #22