### PR TITLE
feat(video): add GPU recovery tool for NVIDIA Code 22 disabled state

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The master template lives in [`project-scaffolding/docs/agents/`](../project-sca
 - **`video_download.py`** - Unified video downloader (YouTube, HLS/M3U8, direct URL) with GUI
 - **`video_reencoder.py`** - Video format conversion and re-encoding
 
+**GPU Maintenance**
+- **`gpu_recovery.py`** - Diagnose & recover an NVIDIA GPU stuck "disabled" (Device Manager Code 22); restores NVENC acceleration for the tools above (see `gpu_recovery.md`)
+
 ### 📚 Notion Integration (`notion/`)
 
 **Database Management**

--- a/video/gpu_recovery.bat
+++ b/video/gpu_recovery.bat
@@ -1,0 +1,55 @@
+@echo off
+REM ============================================================================
+REM GPU RECOVERY BATCH SCRIPT
+REM ============================================================================
+REM Description: Diagnose and recover an NVIDIA GPU that Windows marked
+REM              "disabled" (Device Manager Code 22). Falls back to the
+REM              Microsoft Basic Render Driver when that happens, killing
+REM              NVENC acceleration for the video tools in this folder.
+REM              See gpu_recovery.md for the full story and the fix.
+REM
+REM Usage: Double-click this bat file (it requests admin), or run from a
+REM        terminal. Enabling a device requires administrator rights.
+REM ============================================================================
+
+REM --- Self-elevate: re-launch this script with admin rights if needed --------
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    echo [INFO] Requesting administrator privileges...
+    "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -Command "Start-Process -FilePath '%~f0' -ArgumentList '%*' -Verb RunAs"
+    exit /b
+)
+
+echo [INFO] Starting GPU Recovery (administrator)...
+
+REM Read the virtual environment path from .env file
+for /f "tokens=2 delims==" %%a in ('findstr "VENV_FOLDER" "E:\automation\automation\.env"') do set "VENV_DIR=%%a"
+if not defined VENV_DIR (
+    echo [WARNING] Could not read VENV_FOLDER from .env file. Using default path...
+    set "VENV_DIR=E:\automation\automation\.venv"
+)
+
+REM Set the path to the video scripts
+set "SCRIPT_DIR=E:\automation\automation\video"
+
+echo [INFO] Using virtual environment: "%VENV_DIR%"
+echo [INFO] Changing to script directory: "%SCRIPT_DIR%"
+
+cd /d "%SCRIPT_DIR%"
+if errorlevel 1 (
+    echo [ERROR] Failed to change directory to %SCRIPT_DIR%
+    pause
+    exit /b 1
+)
+
+echo [INFO] Running gpu_recovery.py %*...
+"%VENV_DIR%\Scripts\python.exe" gpu_recovery.py %*
+if errorlevel 1 (
+    echo [ERROR] gpu_recovery.py returned an error code: %errorlevel%
+    echo [INFO] Check the output above for details.
+    pause
+    exit /b 1
+)
+
+echo [INFO] GPU Recovery completed.
+pause

--- a/video/gpu_recovery.md
+++ b/video/gpu_recovery.md
@@ -1,0 +1,93 @@
+# GPU Recovery
+
+Diagnose and recover an NVIDIA GPU that Windows has marked **disabled** (Device Manager **Code 22**). When the card drops into this state, Windows falls back to the *Microsoft Basic Render Driver*, `nvidia-smi` stops responding, and every NVENC-accelerated tool in this `video/` folder (re-encoder, screen recorder, etc.) silently loses GPU acceleration. This tool detects the condition and applies the one fix that actually works.
+
+## The symptom
+
+- NVIDIA app shows **"No driver installed"**.
+- Windows → System → About shows **"No dedicated VRAM / No GPU installed"** and *Microsoft Basic Render Driver*.
+- Device Manager still lists the card by its correct name, but with an error.
+- `nvidia-smi` fails or reports no device.
+
+The card still appears in Device Manager with its real name, which means **the GPU is healthy and present on the PCIe bus** — it is not dead and not a driver crash. Confirm with:
+
+```powershell
+Get-PnpDevice -PresentOnly -Class Display |
+  Where-Object { $_.InstanceId -like 'PCI\VEN_10DE*' } |
+  Select-Object FriendlyName, Status, ConfigManagerErrorCode
+```
+
+`ConfigManagerErrorCode = 22` is the giveaway: **Code 22 = "this device is disabled."** Not Code 43 (fell off the bus), not Code 10 (cannot start), not Code 31 (driver problem) — just *switched off*.
+
+## Root cause and the non-obvious trap
+
+The card gets **disabled** — by a manual Device Manager click, or by a utility (on this machine, **MSI Center** is the prime suspect; there is *no* crash/TDR in the event log when it happens). That part is mundane. The trap is the fix:
+
+> **The PowerShell `Enable-PnpDevice` cmdlet reports success but does *not* actually start the device.**
+
+It returns cleanly, but the card stays at Code 22 through:
+
+- `Enable-PnpDevice` (clears the registry disable-flag, `ConfigFlags = 0`, but the devnode never starts)
+- a PnP rescan (`pnputil /scan-devices`)
+- a disable → enable cycle
+- cycling the **parent PCIe root port**
+- **a full reboot**
+
+The native tool does the real enable in one shot:
+
+```powershell
+pnputil /enable-device "PCI\VEN_10DE&DEV_2D04&...&REV_A1\<serial>"
+```
+
+```
+Enabling device: ...RTX 5060 Ti
+Device enabled successfully.
+```
+
+→ immediately back to `Status = OK / Code 0`, driver loaded, `nvidia-smi` responding. **No reboot needed.** `gpu_recovery.py` wraps exactly this: discover the disabled NVIDIA adapter, run `pnputil /enable-device`, verify with `nvidia-smi`.
+
+## Requirements
+
+- Windows + an NVIDIA GPU.
+- **Administrator rights** (enabling a device requires them — the `.bat` self-elevates via UAC).
+- Python 3.x (standard library only — no extra packages).
+
+## Running
+
+**Recommended — double-click** `gpu_recovery.bat`. It requests admin (accept the UAC prompt), diagnoses the GPU, and fixes it if it finds it disabled.
+
+**From a terminal:**
+
+```bash
+python gpu_recovery.py             # diagnose, then fix if disabled (needs admin to fix)
+python gpu_recovery.py --diagnose  # report only, make no changes
+```
+
+The GPU's device-instance ID is **discovered dynamically** — nothing is hardcoded, so the tool works on any machine/card.
+
+## What it does
+
+1. Enumerates present NVIDIA display adapters and reads each one's `ConfigManagerErrorCode` and registry `ConfigFlags`.
+2. Runs `nvidia-smi` to show whether the card is live.
+3. If any GPU is at **Code 22**, runs `pnputil /enable-device <instance>` (admin) and re-verifies.
+4. If the card *stays* Code 22 after the enable, prints recent System-log events touching the device — to help track down what is re-disabling it.
+
+## Output (healthy result)
+
+```
+✅ Recovered. nvidia-smi: NVIDIA GeForce RTX 5060 Ti, 591.86, 16311 MiB, 33, 9 %
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "Enabling the device needs administrator rights" | Use `gpu_recovery.bat` (self-elevates), or run an elevated terminal. |
+| No NVIDIA adapter found | Card may be physically unseated or not enumerating — check the slot / power; this is then a hardware issue, not Code 22. |
+| Still Code 22 after the fix | Something is actively re-disabling it. Check the printed System-log events, MSI Center, and Task Scheduler. |
+| Windows shows "4 GB" VRAM | Cosmetic — the WMI `AdapterRAM` field overflows at 4 GB. Trust `nvidia-smi` (reports the true 16 GB). |
+| `nvidia-smi` "insufficient permissions" | Run elevated, or simply confirm via Device Manager that the status is OK. |
+
+## Related
+
+- `video_reencoder.py`, `screen_recorder.py` — the NVENC-dependent tools this recovery protects.

--- a/video/gpu_recovery.py
+++ b/video/gpu_recovery.py
@@ -1,0 +1,285 @@
+"""
+GPU Recovery - Diagnose and recover an NVIDIA GPU that Windows has marked
+"disabled" (Device Manager Code 22).
+
+Why this exists
+---------------
+On this machine an NVIDIA RTX 5060 Ti has intermittently ended up *disabled*
+(Device Manager problem Code 22) with no crash, TDR, or driver fault in the
+event log. When that happens Windows falls back to the "Microsoft Basic
+Render Driver", `nvidia-smi` stops responding, and every NVENC-based tool in
+this `video/` folder silently loses GPU acceleration.
+
+The non-obvious trap: the PowerShell `Enable-PnpDevice` cmdlet *reports
+success but does not actually start the device* - the card stays at Code 22
+through enable/disable cycles, parent-port cycles, and even a reboot. The
+native `pnputil /enable-device` performs the real enable in one shot.
+
+This tool diagnoses the GPU state and, if it finds the card disabled, applies
+the working fix (`pnputil /enable-device`) and verifies recovery with
+`nvidia-smi`. Enabling a device needs administrator rights; `gpu_recovery.bat`
+self-elevates before launching this script.
+
+Usage
+-----
+    python gpu_recovery.py            # diagnose, then fix if disabled
+    python gpu_recovery.py --diagnose # report only, make no changes
+"""
+
+import argparse
+import ctypes
+import json
+import logging
+import os
+import subprocess
+import sys
+from typing import Optional
+
+# UTF-8 stdout so emoji/box characters survive redirected/captured runs on
+# Windows (cp1252 fallback otherwise throws UnicodeEncodeError under capture).
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except (AttributeError, ValueError):
+    pass
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger("gpu_recovery")
+
+POWERSHELL = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+PNPUTIL = os.path.join(os.environ.get("WINDIR", r"C:\Windows"), "System32", "pnputil.exe")
+NVIDIA_VENDOR_PREFIX = "PCI\\VEN_10DE"
+
+# Device Manager ConfigManagerErrorCode -> human meaning (the ones we care about).
+CODE_MEANINGS = {
+    0: "OK - working normally",
+    10: "Code 10 - device cannot start (driver/init failure)",
+    22: "Code 22 - device is DISABLED",
+    28: "Code 28 - drivers not installed",
+    31: "Code 31 - device not working properly (driver problem)",
+    43: "Code 43 - Windows stopped it after a reported fault (fell off the bus)",
+}
+
+
+def is_admin() -> bool:
+    """True if the current process holds administrator rights."""
+    try:
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())
+    except OSError:
+        return False
+
+
+def _powershell(script: str) -> str:
+    """Run a Windows PowerShell snippet and return its stdout (empty on error)."""
+    try:
+        result = subprocess.run(
+            [POWERSHELL, "-NoProfile", "-NonInteractive", "-Command", script],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        return result.stdout.strip()
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.warning("⚠️  PowerShell call failed: %s", exc)
+        return ""
+
+
+def find_nvidia_gpus() -> list[dict]:
+    """Discover present NVIDIA display adapters and their problem state.
+
+    Returns a list of dicts: {FriendlyName, InstanceId, Status, ConfigManagerErrorCode}.
+    The instance id is discovered dynamically so the tool is portable across
+    machines/cards - nothing is hardcoded.
+    """
+    script = (
+        "Get-PnpDevice -PresentOnly -Class Display | "
+        f"Where-Object {{ $_.InstanceId -like '{NVIDIA_VENDOR_PREFIX}*' }} | "
+        "Select-Object FriendlyName, InstanceId, Status, ConfigManagerErrorCode | "
+        "ConvertTo-Json -Compress"
+    )
+    raw = _powershell(script)
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    # ConvertTo-Json emits a bare object for a single item, a list for many.
+    return data if isinstance(data, list) else [data]
+
+
+def read_config_flags(instance_id: str) -> Optional[int]:
+    """Read the device's registry ConfigFlags (0 = enabled, bit 0x1 = disabled)."""
+    safe = instance_id.replace("'", "''")
+    script = (
+        "$k = Get-ItemProperty "
+        f"'HKLM:\\SYSTEM\\CurrentControlSet\\Enum\\{safe}' "
+        "-Name ConfigFlags -ErrorAction SilentlyContinue; "
+        "if ($null -ne $k) { $k.ConfigFlags } else { 'NA' }"
+    )
+    raw = _powershell(script)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def nvidia_smi() -> Optional[str]:
+    """Return a one-line nvidia-smi summary, or None if the GPU isn't live."""
+    smi = os.path.join(os.environ.get("WINDIR", r"C:\Windows"), "System32", "nvidia-smi.exe")
+    exe = smi if os.path.exists(smi) else "nvidia-smi"
+    try:
+        result = subprocess.run(
+            [
+                exe,
+                "--query-gpu=name,driver_version,memory.total,temperature.gpu,utilization.gpu",
+                "--format=csv,noheader",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return None
+
+
+def recent_events(instance_id: str) -> list[str]:
+    """Best-effort: recent System-log lines referencing this device (last 2 days).
+
+    Helps answer the open question of *what* disabled the card - a manual
+    Device Manager click or a utility (e.g. MSI Center) leaves a trail here.
+    """
+    # Match on the VEN/DEV core; the full instance id rarely appears verbatim.
+    core = instance_id.split("\\")[1] if "\\" in instance_id else instance_id
+    script = (
+        "Get-WinEvent -FilterHashtable @{LogName='System'; "
+        "StartTime=(Get-Date).AddDays(-2)} -ErrorAction SilentlyContinue | "
+        "Where-Object { $_.ProviderName -match 'Kernel-PnP|nvlddmkm' -or "
+        f"$_.Message -match '{core}|RTX 50|nvlddmkm' }} | "
+        "Select-Object -First 12 TimeCreated, Id, ProviderName | "
+        "ForEach-Object { '{0}  [{1}] {2}' -f $_.TimeCreated, $_.Id, $_.ProviderName }"
+    )
+    raw = _powershell(script)
+    return [line for line in raw.splitlines() if line.strip()]
+
+
+def enable_device(instance_id: str) -> bool:
+    """Enable a disabled device via native pnputil (the call that actually works)."""
+    if not is_admin():
+        logger.error("❌ Enabling the device needs administrator rights. "
+                     "Run gpu_recovery.bat (it self-elevates).")
+        return False
+    logger.info("🔧 Enabling via: pnputil /enable-device \"%s\"", instance_id)
+    try:
+        result = subprocess.run(
+            [PNPUTIL, "/enable-device", instance_id],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.error("❌ pnputil failed: %s", exc)
+        return False
+    logger.info(result.stdout.strip() or result.stderr.strip())
+    return result.returncode == 0
+
+
+def describe_code(code: Optional[int]) -> str:
+    if code is None:
+        return "unknown"
+    return CODE_MEANINGS.get(code, f"Code {code} (see Microsoft Device Manager error codes)")
+
+
+def diagnose() -> list[dict]:
+    """Print a diagnostic report and return the discovered GPU records."""
+    logger.info("=" * 70)
+    logger.info("NVIDIA GPU diagnostic")
+    logger.info("=" * 70)
+
+    gpus = find_nvidia_gpus()
+    if not gpus:
+        logger.warning("⚠️  No present NVIDIA display adapter found. The card may "
+                       "be physically absent, or not enumerating on the PCIe bus.")
+        return gpus
+
+    for gpu in gpus:
+        name = gpu.get("FriendlyName", "NVIDIA GPU")
+        instance = gpu.get("InstanceId", "")
+        code = gpu.get("ConfigManagerErrorCode")
+        flags = read_config_flags(instance)
+        logger.info("")
+        logger.info("• %s", name)
+        logger.info("    Instance     : %s", instance)
+        logger.info("    State        : %s", describe_code(code))
+        logger.info("    ConfigFlags  : %s%s", flags,
+                    "  (0 = enabled in registry)" if flags == 0 else "")
+
+    smi = nvidia_smi()
+    logger.info("")
+    if smi:
+        logger.info("✅ nvidia-smi: %s", smi)
+    else:
+        logger.info("ℹ️  nvidia-smi: no response (expected while the GPU is disabled).")
+
+    return gpus
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Diagnose/recover a disabled NVIDIA GPU (Code 22).")
+    parser.add_argument("--diagnose", action="store_true",
+                        help="Report only; make no changes.")
+    args = parser.parse_args()
+
+    gpus = diagnose()
+    if not gpus:
+        return 1
+
+    disabled = [g for g in gpus if g.get("ConfigManagerErrorCode") == 22]
+
+    if not disabled:
+        logger.info("")
+        logger.info("✅ Nothing to fix - no NVIDIA GPU is in the Code 22 disabled state.")
+        return 0
+
+    if args.diagnose:
+        logger.info("")
+        logger.info("⚠️  %d GPU(s) disabled. Re-run without --diagnose to fix.", len(disabled))
+        return 2
+
+    logger.info("")
+    logger.info("Found %d disabled GPU(s). Applying fix...", len(disabled))
+    all_ok = True
+    for gpu in disabled:
+        instance = gpu.get("InstanceId", "")
+        if not enable_device(instance):
+            all_ok = False
+
+    # Verify recovery.
+    logger.info("")
+    logger.info("Verifying...")
+    post = find_nvidia_gpus()
+    still_bad = [g for g in post if g.get("ConfigManagerErrorCode") == 22]
+    smi = nvidia_smi()
+
+    if not still_bad and smi:
+        logger.info("✅ Recovered. nvidia-smi: %s", smi)
+        return 0
+
+    all_ok = False
+    logger.warning("⚠️  GPU still not fully live after the enable.")
+    if still_bad:
+        logger.warning("    Still Code 22 - something may be actively re-disabling it.")
+        hints = recent_events(still_bad[0].get("InstanceId", ""))
+        if hints:
+            logger.warning("    Recent System-log events touching the device:")
+            for line in hints:
+                logger.warning("      %s", line)
+            logger.warning("    Suspect a utility (e.g. MSI Center) or a scheduled task.")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a self-contained GPU recovery tool to `video/`, where the NVENC-dependent tools live. When the NVIDIA GPU drops into Windows' "disabled" state (Device Manager **Code 22**) — which kills NVENC for `video_reencoder.py`, `screen_recorder.py`, etc. — this tool diagnoses it and applies the fix that actually works: `pnputil /enable-device` (the PowerShell `Enable-PnpDevice` cmdlet reports success but silently no-ops).

- **`gpu_recovery.py`** — discovers the NVIDIA adapter dynamically (no hardcoded instance id), reports `ConfigManagerErrorCode` / registry `ConfigFlags` / `nvidia-smi`, and enables + verifies when it finds Code 22. `--diagnose` is read-only.
- **`gpu_recovery.bat`** — self-elevates via UAC (enabling a device needs admin), mirrors the existing video `.bat` pattern.
- **`gpu_recovery.md`** — symptom, root cause, the cmdlet-vs-pnputil trap, usage, troubleshooting.
- **README** — lists the tool under `video/`.

Stdlib-only; follows project conventions (`logging`, type hints, UTF-8 stdout guard).

## Validation

- `py -m py_compile video/gpu_recovery.py` → exit 0.
- `python gpu_recovery.py --diagnose` run live: correctly reports the (now-healthy) RTX 5060 Ti as `OK / Code 0` with `nvidia-smi` responding.
- No `.github/workflows` in this repo — no CI to await.

Closes #34
