### PR TITLE
docs(wifi): fix venv path drift in network_scanner docstrings and README

### DIFF
--- a/system/wifi/network_scanner.md
+++ b/system/wifi/network_scanner.md
@@ -56,18 +56,7 @@ If you prefer not to install WinPcap/Npcap on Windows:
 ### Linux/macOS
 ```bash
 # With sudo
-sudo ./venv/bin/python system/wifi/network_scanner.py
-```
-
-### Alternative: Activate venv first
-```bash
-# Linux/macOS
-source venv/bin/activate
-sudo python system/wifi/network_scanner.py
-
-# Windows PowerShell
-.\.venv\Scripts\activate
-.\.venv\Scripts\python.exe system\wifi\network_scanner.py
+sudo ./.venv/bin/python system/wifi/network_scanner.py
 ```
 
 ## 📊 Usage Examples

--- a/system/wifi/network_scanner.py
+++ b/system/wifi/network_scanner.py
@@ -71,12 +71,7 @@ How to Run:
         .\.venv\Scripts\python.exe network_scanner.py
 
     Linux/macOS (with sudo):
-        sudo ./venv/bin/python network_scanner.py
-
-    Or activate virtual environment and run:
-        source venv/bin/activate  # Linux/macOS
-        .\.venv\Scripts\activate  # Windows PowerShell
-        python network_scanner.py
+        sudo ./.venv/bin/python network_scanner.py
 """
 
 import argparse
@@ -691,12 +686,8 @@ Windows (PowerShell):
 
 Linux/macOS:
     1. Open terminal
-    2. Run: sudo ./venv/bin/python network_scanner.py
+    2. Run: sudo ./.venv/bin/python network_scanner.py
     3. Enter your password when prompted
-
-Alternatively, activate virtual environment first:
-    source venv/bin/activate  # Linux/macOS
-    sudo python network_scanner.py
 
 VirtualBox/VM Users:
     - Ensure your VM has "Bridged Adapter" network mode


### PR DESCRIPTION
## Summary

- Replaces bare `venv/bin/python` with `.venv/bin/python` in the module-level docstring and the runtime privilege-error message (four drift sites identified in #36)
- Removes the activate-venv block from both the Python docstring and the markdown README — activation is forbidden by CLAUDE.md; direct `.venv` invocation is the canonical pattern
- Fixes `system/wifi/network_scanner.md` in lock-step (path fix + section removal)

## Validation

- **Syntax gate:** `py_compile system/wifi/network_scanner.py` → exit 0 (pre-existing `\.` SyntaxWarnings in unrelated Windows-path strings, not introduced by this change)
- **Tests:** no project-level tests for this module (pytest not installed in venv); change is doc/docstring-only, no executable logic touched
- **Diff sweep:** only the two files listed in the issue changed; no test removals, no logic changes, no unintended hunks
- **Behavioural:** docstring + markdown text change only — correctness verified by reading the diff against the four cited line numbers

Closes #36