### PR TITLE
chore: add .fleet.toml self-describing fleet metadata

### DIFF
--- a/.fleet.toml
+++ b/.fleet.toml
@@ -1,0 +1,7 @@
+# .fleet.toml — this repo's card on the fleet architecture map.
+# fleet-config's /system-map aggregates every repo's .fleet.toml. Keep current:
+# update in the same PR as any material change (layer, port, role, one-line
+# description, exposed services). Schema: fleet-config/architecture/README.md.
+layer       = "working-pipe"
+icon        = "🤖"
+description = "Python automation grab-bag."


### PR DESCRIPTION
Adds this repo's architecture-map card per ferraroroberto/fleet-config#148. Config-only (no code, no e2e surface).

Closes #42