### PR TITLE
feat: add HEIC/HEIF support to image_to_pdf_collate

### DIFF
--- a/image/image_to_pdf_collate.py
+++ b/image/image_to_pdf_collate.py
@@ -6,11 +6,14 @@ from tkinter import filedialog, messagebox
 from typing import Optional
 
 from PIL import Image
+import pillow_heif
+
+pillow_heif.register_heif_opener()
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
-IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tiff", ".tif", ".webp"}
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tiff", ".tif", ".webp", ".heic", ".heif"}
 
 
 def collect_images(folder: Path) -> list[Path]:


### PR DESCRIPTION
## Summary

- Register `pillow_heif` opener at import time so Pillow can decode HEIC/HEIF files.
- Add `.heic` and `.heif` to `IMAGE_EXTENSIONS`. `pillow-heif` is already in `requirements.txt` — no new dependency.

## Validation

- **syntax**: `py_compile` exit 0 OK
- **behavioural**: ran headless test against a real folder of 6 HEIC photos (`E:\onedrive\...\informe evolutivo y actualización 2026-06`); PDF generated at 5,922,545 bytes OK

Closes #46