### PR TITLE
docs: add LICENSE file and fix PySimpleGUI acknowledgment

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Roberto Ferraro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 - OpenAI Whisper for speech recognition
 - Notion API for database integration
-- PySimpleGUI for user interface components
+- PySimpleGUI for user interface components in `system/keycaster.py` and `system/quickdeck/` *(note: PySimpleGUI is no longer freely available on PyPI — it requires a paid license or registration; these two tools need a separately-obtained PySimpleGUI installation, or can be migrated to the drop-in [FreeSimpleGUI](https://github.com/spyoungtech/FreeSimpleGUI) fork)*
 - FFmpeg for audio/video processing
 
 ---


### PR DESCRIPTION
## Summary

- Added the MIT `LICENSE` file that `README.md` has always referenced (line 363: "see the LICENSE file for details") but that was never committed to the repo.
- Updated the Acknowledgments section to document that PySimpleGUI is no longer freely available on PyPI — it requires a paid license or registration. Named the two scripts that still import it (`system/keycaster.py`, `system/quickdeck/quickdeck.py`) and pointed to [FreeSimpleGUI](https://github.com/spyoungtech/FreeSimpleGUI) as the drop-in migration path. This aligns the README with what `requirements.txt` itself already states.

## Validation

- **3b Syntax/lint:** docs-only change — no Python files touched, nothing to compile.
- **3c Tests:** no test suite covers README/LICENSE content.
- **3d E2E:** no CI workflows exist in this repo.
- **3e Behavioural:** LICENSE file now exists at repo root; README license section no longer references a missing file. PySimpleGUI note accurately reflects `requirements.txt` comment and the two import sites.
- **3f Sanity sweep:** diff touches only `LICENSE` (new) and `README.md` (one line changed). Nothing outside stated scope.
- **3g Self-critique:** no tests removed, no assertions weakened, no dependency changes, no `.gitignore` edits.

Closes #51