### PR TITLE
refactor: strip hardcoded personal paths to env-only defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,15 @@ NOTION_DATABASE_ID=your_database_id
 # Audio settings
 AUDIO_OUTPUT_PATH=path/to/audio/output
 DEFAULT_LANGUAGE=Spanish
+
+# Machine-local folder paths (no hardcoded defaults — must be set per machine)
+NOTION_PARAMS_FILE=         # path to the legacy notion-params.txt file (notion/utils.py)
+ILLUSTRATIONS_DEST_INSTAGRAM=  # destination folder for Instagram-formatted illustrations (image/illustrations_formatter*.py)
+ILLUSTRATIONS_DEST_1920X1080=  # destination folder for 1920×1080 illustrations (image/illustrations_formatter*.py)
+CARROUSEL_SOURCE_FOLDER=    # source folder of carrousel PDF files (image/carrousel_pdf_to_jpg.py)
+POPPLER_PATH=               # path to Poppler bin dir if not on system PATH (image/carrousel_pdf_to_jpg.py)
+COLLAGE_SOURCE_FOLDER=      # source folder for collage images (image/collage_image.py)
+TODOIST_SOURCE_FOLDER=      # source folder for Todoist CSV backup files (notion/todoist_migration.py)
 ```
 
 ### **JSON Configuration Files**

--- a/image/carrousel_pdf_to_jpg.py
+++ b/image/carrousel_pdf_to_jpg.py
@@ -11,11 +11,11 @@ from tkinter import messagebox
 
 log = logging.getLogger(__name__)
 
-# Hardcoded source folder
-HARDCODED_SOURCE_FOLDER = r"C:\Users\rober\iCloudDrive\6LVTQB9699~com~seriflabs~affinitydesigner\Roberto\thread\books"
+# Source folder — set the CARROUSEL_SOURCE_FOLDER environment variable on each machine
+HARDCODED_SOURCE_FOLDER = os.getenv("CARROUSEL_SOURCE_FOLDER", "")
 
-# Specify Poppler path if not added to system PATH
-POPPLER_PATH = r"E:\onedrive\Documentos\Roberto\projects\automation\notion-automation-files\poppler\Library\bin"  # Update this path as per your installation
+# Poppler path if not added to system PATH — set the POPPLER_PATH environment variable on each machine
+POPPLER_PATH = os.getenv("POPPLER_PATH", "")
 
 
 def find_pdf_files(root_folder):

--- a/image/collage_image.py
+++ b/image/collage_image.py
@@ -7,8 +7,8 @@ from PIL import Image
 
 log = logging.getLogger(__name__)
 
-# Hardcoded path for the folder containing images
-source_folder = r"E:\onedrive\Documentos\Roberto\projects\speaking\ISDI"
+# Folder containing images — set the COLLAGE_SOURCE_FOLDER environment variable on each machine
+source_folder = os.getenv("COLLAGE_SOURCE_FOLDER", "")
 
 # Base dimensions for an A4 sheet at 300 DPI
 BASE_WIDTH = 2480  # A4 width in pixels at 300 DPI

--- a/image/illustrations_formatter.py
+++ b/image/illustrations_formatter.py
@@ -85,16 +85,8 @@ class IllustrationsFormatter:
         default_config = {
             'source_folder': '',
             'destination_folder': '',
-            'destination_folder_instagram': (
-                r'C:\Users\rober\iCloudDrive'
-                r'\6LVTQB9699~com~seriflabs~affinitydesigner'
-                r'\Roberto\archived_IGformat'
-            ),
-            'destination_folder_1920x1080': (
-                r'C:\Users\rober\iCloudDrive'
-                r'\6LVTQB9699~com~seriflabs~affinitydesigner'
-                r'\Roberto\archived_1920x1080'
-            ),
+            'destination_folder_instagram': os.getenv('ILLUSTRATIONS_DEST_INSTAGRAM', ''),
+            'destination_folder_1920x1080': os.getenv('ILLUSTRATIONS_DEST_1920X1080', ''),
             'aspect_ratio': '3:4',
             'background_color': '',
             'format_type': 'instagram',

--- a/image/illustrations_formatter_gui.py
+++ b/image/illustrations_formatter_gui.py
@@ -68,16 +68,8 @@ class IllustrationsFormatterGUI:
     """
 
     CONFIG_FILE = 'illustrations_formatter_config.json'
-    DEFAULT_1920X1080_FOLDER = (
-        r'C:\Users\rober\iCloudDrive'
-        r'\6LVTQB9699~com~seriflabs~affinitydesigner'
-        r'\Roberto\archived_1920x1080'
-    )
-    DEFAULT_INSTAGRAM_FOLDER = (
-        r'C:\Users\rober\iCloudDrive'
-        r'\6LVTQB9699~com~seriflabs~affinitydesigner'
-        r'\Roberto\archived_IGformat'
-    )
+    DEFAULT_1920X1080_FOLDER = os.getenv('ILLUSTRATIONS_DEST_1920X1080', '')
+    DEFAULT_INSTAGRAM_FOLDER = os.getenv('ILLUSTRATIONS_DEST_INSTAGRAM', '')
 
     def __init__(self, root: tk.Tk):
         self.root = root

--- a/notion/notion_databases_add_editorial.py
+++ b/notion/notion_databases_add_editorial.py
@@ -19,7 +19,7 @@ from notion_client import Client
 
 
 
-from utils import read_params_from_txt_file
+from utils import read_params_from_txt_file, DEFAULT_PARAMS_FILE
 
 
 
@@ -389,7 +389,7 @@ def main():
 
         type=str,
 
-        default=r"C:\Mis Datos en Local\temporal\python\notion-params.txt",
+        default=DEFAULT_PARAMS_FILE,
 
         help="Path to notion-params.txt (api_token)",
 

--- a/notion/notion_databases_clean.py
+++ b/notion/notion_databases_clean.py
@@ -13,7 +13,7 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
 # requirements: custom functions
-from utils import read_params_from_txt_file, get_column_widths, apply_column_widths
+from utils import read_params_from_txt_file, get_column_widths, apply_column_widths, DEFAULT_PARAMS_FILE
 
 # Suppress openpyxl warnings
 warnings.filterwarnings("ignore", category=UserWarning, module="openpyxl.worksheet._reader")
@@ -186,7 +186,7 @@ def process_databases(databases_to_process, metadata):
 
 # Main execution
 
-params_file_path = r"C:\Mis Datos en Local\temporal\python\notion-params.txt"
+params_file_path = DEFAULT_PARAMS_FILE
 log.info("📂 Loading parameters...")
 params = read_params_from_txt_file(params_file_path)
 log.info("✅ Parameters loaded")

--- a/notion/notion_databases_dump.py
+++ b/notion/notion_databases_dump.py
@@ -10,7 +10,7 @@ logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
 # requirements: custom functions
-from utils import read_params_from_txt_file
+from utils import read_params_from_txt_file, DEFAULT_PARAMS_FILE
 from utils import get_column_widths
 from utils import apply_column_widths
 
@@ -144,7 +144,7 @@ def read_database_list(excel_path):
 # Main execution
 
 # Load the parameters from the text file
-params_file_path = r"C:\Mis Datos en Local\temporal\python\notion-params.txt"
+params_file_path = DEFAULT_PARAMS_FILE
 log.info("📂 Loading parameters...")
 params = read_params_from_txt_file(params_file_path)
 log.info("✅ Parameters loaded")

--- a/notion/notion_databases_editorial.py
+++ b/notion/notion_databases_editorial.py
@@ -5,7 +5,7 @@ import warnings
 from openpyxl import load_workbook
 
 # requirements: custom functions
-from utils import read_params_from_txt_file
+from utils import read_params_from_txt_file, DEFAULT_PARAMS_FILE
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ def editorial_databases(databases_to_editorial):
 
 # Main execution
 
-params_file_path = r"C:\Mis Datos en Local\temporal\python\notion-params.txt"
+params_file_path = DEFAULT_PARAMS_FILE
 params = read_params_from_txt_file(params_file_path)
 
 excel_path = params['excel_path']

--- a/notion/notion_databases_query.py
+++ b/notion/notion_databases_query.py
@@ -4,7 +4,7 @@ import pandas as pd
 from notion_client import Client
 
 # requirements: custom functions
-from utils import read_params_from_txt_file
+from utils import read_params_from_txt_file, DEFAULT_PARAMS_FILE
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ def save_to_excel(databases, db_excel_path):
 # Main execution
 
 # Load the parameters from the text file
-params_file_path = r"C:\Mis Datos en Local\temporal\python\notion-params.txt"
+params_file_path = DEFAULT_PARAMS_FILE
 params = read_params_from_txt_file(params_file_path)
 
 # Get the api_token

--- a/notion/notion_excel_sync.py
+++ b/notion/notion_excel_sync.py
@@ -2,7 +2,7 @@ import logging
 import pandas as pd
 from notion_client import Client, APIResponseError
 import time
-from utils import read_params_from_txt_file
+from utils import read_params_from_txt_file, DEFAULT_PARAMS_FILE
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger(__name__)
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 # chatGPT source > https://chat.openai.com/c/2bfb9ae6-233d-46fe-8171-69e7e1929866
 # chatGPT source > https://chat.openai.com/c/025bb803-a79e-4be1-851f-fbb249db6e38
 
-params_file_path = r"C:\Mis Datos en Local\temporal\python\notion-params.txt"
+params_file_path = DEFAULT_PARAMS_FILE
 params = read_params_from_txt_file(params_file_path)
 
 sync_path = params['sync_path']

--- a/notion/todoist_migration.py
+++ b/notion/todoist_migration.py
@@ -6,8 +6,8 @@ from datetime import datetime
 
 log = logging.getLogger(__name__)
 
-# Set the source folder where the CSV files are located
-HARDCODED_SOURCE_FOLDER = r"D:\OneDrive\Documentos\Roberto\projects\automation\notion-automation-files\todoist\Todoist backup 2024-08-14 2318 UTC"
+# Source folder where the CSV files are located — set the TODOIST_SOURCE_FOLDER environment variable on each machine
+HARDCODED_SOURCE_FOLDER = os.getenv("TODOIST_SOURCE_FOLDER", "")
 
 
 # Function to determine if DATE is an actual date or a recurring pattern

--- a/notion/utils.py
+++ b/notion/utils.py
@@ -101,6 +101,10 @@ def get_first_explorer_folder_path():
 
     return None
 
+# Default location of the legacy notion params txt file (single source of truth).
+# Set the NOTION_PARAMS_FILE environment variable to the path on each machine.
+DEFAULT_PARAMS_FILE = os.getenv("NOTION_PARAMS_FILE", "")
+
 # Function to read the parameters from the txt file (legacy support)
 def read_params_from_txt_file(file_path):
     params = {}


### PR DESCRIPTION
## Summary

- `notion/utils.py`: `DEFAULT_PARAMS_FILE` is the single source of truth; fallback changed from a personal `C:\Mis Datos\...` literal to `""` (set `NOTION_PARAMS_FILE` env var per machine)
- `image/illustrations_formatter.py` + `image/illustrations_formatter_gui.py`: `ILLUSTRATIONS_DEST_INSTAGRAM` / `ILLUSTRATIONS_DEST_1920X1080` defaults stripped from iCloud personal paths to `""`
- `image/carrousel_pdf_to_jpg.py`: `CARROUSEL_SOURCE_FOLDER` and `POPPLER_PATH` personal literals replaced with `""`
- `image/collage_image.py`: `COLLAGE_SOURCE_FOLDER` OneDrive literal replaced with `""`
- `notion/todoist_migration.py`: `TODOIST_SOURCE_FOLDER` OneDrive literal replaced with `""`
- `README.md`: new env-var table under Configuration lists all seven variables with one-line descriptions

The six notion modules that already import `DEFAULT_PARAMS_FILE` from `notion/utils.py` are unchanged — the dedup structure from the previous commit is preserved.

## Test plan

- [x] `py -m py_compile` on all six changed modules — passes (ALL OK)
- [x] grep for `C:\Users\rober`, `C:\Mis Datos`, `iCloudDrive`, `onedrive\Documentos`, `OneDrive\Documentos` across changed files — zero matches

Closes #49