### PR TITLE
chore: remove AI provenance header comments across 15 scripts

### DIFF
--- a/audio/convert_ogg_mp3.py
+++ b/audio/convert_ogg_mp3.py
@@ -1,5 +1,3 @@
-# source chatGPT > https://chatgpt.com/c/67a4e5d8-22d8-8009-b78b-3d3d7697e06a
-
 import logging
 import os
 import tkinter as tk

--- a/image/carrousel_pdf_to_jpg.py
+++ b/image/carrousel_pdf_to_jpg.py
@@ -1,6 +1,3 @@
-# chatGPT source and first iteration > https://chatgpt.com/c/5001a6f9-4247-4a02-b6e9-2a84acd468f5
-# log execution > https://onedrive.live.com/edit.aspx?resid=5492cf8639ca0b0b!196221
-
 import logging
 import os
 import sys

--- a/image/collage_image.py
+++ b/image/collage_image.py
@@ -1,5 +1,3 @@
-# source chatGPT 2024-09-21 > https://chatgpt.com/c/66eed755-cfe8-8009-9030-25642e2ce043
-
 import logging
 import os
 import random

--- a/image/photos_archive.py
+++ b/image/photos_archive.py
@@ -12,13 +12,6 @@ Configuration: photos_archive.json (follows AGENTS.md guidelines)
 - behavior_flags: Control prompts and automation behavior
 - file_extensions: Supported image/video formats
 - date_parsing: Regex patterns for filename date extraction
-
-References:
-- https://chatgpt.com/c/9887f68a-8392-40a9-a648-321dc77ff475 (long version)
-- https://chatgpt.com/c/9aaeba93-8e88-416f-a502-0e4d4bfe9270 (video dates)
-- https://chatgpt.com/c/c8d6ca75-c05d-4a35-9360-dae22274c732 (pattern recognition)
-- https://chatgpt.com/c/d81cead9-9fe0-49f7-a1a8-28d2d45c21d1 (deleting discards)
-- https://chatgpt.com/c/a5bf8310-98ab-4626-8e48-d223bb54d7f7 (source/dest same path)
 """
 
 import os

--- a/image/screenshot.py
+++ b/image/screenshot.py
@@ -1,5 +1,3 @@
-# AI source > https://chatgpt.com/c/67963e0c-6fd8-8009-88b4-df158e8732c2
-
 import logging
 import os
 import sys

--- a/notion/notion_databases_add_editorial.py
+++ b/notion/notion_databases_add_editorial.py
@@ -1,5 +1,3 @@
-# source chatGPT > https://chatgpt.com/c/6724bbf2-a618-8009-a4e3-a1f6e6828ae0
-
 # Run with repo venv: ..\.venv\Scripts\python notion_databases_add_editorial.py (from this folder), or notion_databases_add_editorial.bat
 
 

--- a/notion/notion_databases_clean.py
+++ b/notion/notion_databases_clean.py
@@ -1,6 +1,3 @@
-# chatGPT > improve treatment when I don't have all the columns in metadata, add more debug, treat number fields in extraction
-# https://chatgpt.com/c/9d919945-16dc-4a8a-8f79-8cc2b055ad2f
-
 import logging
 import os
 import sys

--- a/system/apple/convert_to_apple.py
+++ b/system/apple/convert_to_apple.py
@@ -4,9 +4,6 @@ Apple Contacts Converter
 
 This module converts vCard (.vcf) files to Apple-compatible format using a Tkinter GUI.
 It automatically adds the _apple suffix to the output filename.
-
-Author: Automation Team
-Date: 2024-01-15
 """
 
 import tkinter as tk

--- a/system/apple/unify_vcards.py
+++ b/system/apple/unify_vcards.py
@@ -5,9 +5,6 @@ vCard Unification Tool
 This module provides an interactive tool to unify duplicate contacts in vCard files.
 It analyzes contacts for potential duplicates based on name similarity and phone numbers,
 then guides users through an interactive process to merge or keep contacts.
-
-Author: Automation Team
-Date: 2024-01-15
 """
 
 import os

--- a/system/background.py
+++ b/system/background.py
@@ -1,5 +1,3 @@
-# source chatGPT > https://chatgpt.com/c/a0f05392-daee-4295-8401-978e4916e959
-
 import ctypes
 import winreg as reg
 import sys

--- a/system/keycaster.py
+++ b/system/keycaster.py
@@ -1,5 +1,3 @@
-# source: https://chatgpt.com/c/681206f7-0138-8009-b013-ab6bb16200e9
-
 import PySimpleGUI as sg # type: ignore
 import pygetwindow as gw
 import pyautogui as pag

--- a/system/rename_files.py
+++ b/system/rename_files.py
@@ -2,8 +2,6 @@ import logging
 import os
 import re
 
-# source chatGPT 2024-05-25 > https://chatgpt.com/c/1049735e-6d2b-4603-8a4a-8f68b8de8e10
-
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 

--- a/system/wifi/wifi_connect.py
+++ b/system/wifi/wifi_connect.py
@@ -1,5 +1,3 @@
-# source chatGPT > https://chatgpt.com/c/66e5815c-38a8-8009-a7d7-51cd9d956cff
-
 import logging
 import os
 import subprocess

--- a/text/convert_pdf_to_txt.py
+++ b/text/convert_pdf_to_txt.py
@@ -1,5 +1,3 @@
-# AI source > https://chatgpt.com/c/67e66307-4488-8009-89ae-3f34c2c17c49
-
 import os
 import sys
 import logging

--- a/video/screen_recorder.py
+++ b/video/screen_recorder.py
@@ -12,8 +12,6 @@ Dependencies:
 Notes:
 • Lower FPS → smaller files but choppier video.
 • Cursor overlay ensures visibility on light/dark backgrounds.
-
-Author: ChatGPT – April 2025
 """
 
 import tkinter as tk


### PR DESCRIPTION
## Summary

- Delete `# source chatGPT >` / `# AI source >` URL comments from 12 files (audio, image, notion, system, text)
- Remove fictitious `Author: Automation Team` / `Date: 2024-01-15` boilerplate from `system/apple/` docstrings and `Author: ChatGPT` from `video/screen_recorder.py`
- Drop the `References:` chatGPT URL block (5 URLs + header) from `image/photos_archive.py` docstring
- 39 deletions across 15 files — no executable code touched

## Test plan

- [x] `py -m py_compile` on all 15 modified files — 0 errors
- [x] `git diff --stat` confirms deletions only (39 deletions, 0 insertions)

Closes #50