### PR TITLE
fix: resolve ffmpeg at runtime and use portable output dir

### DIFF
--- a/audio/convert_ogg_mp3.py
+++ b/audio/convert_ogg_mp3.py
@@ -2,16 +2,16 @@ import logging
 import os
 import tkinter as tk
 from tkinter import filedialog
+import imageio_ffmpeg
 from pydub import AudioSegment
 
 log = logging.getLogger(__name__)
 
-# Manually set the correct paths for ffmpeg and ffprobe
-ffmpeg_path = r"C:\Users\rober\AppData\Roaming\Python\Python311\site-packages\imageio_ffmpeg\binaries\ffmpeg-win-x86_64-v7.1.exe"
-ffprobe_path = ffmpeg_path  # `imageio_ffmpeg` does not have a separate ffprobe, so use the same path
-
-AudioSegment.converter = ffmpeg_path
-AudioSegment.ffprobe = ffprobe_path
+# Resolve ffmpeg at runtime via imageio_ffmpeg so this works on any machine
+# regardless of Python version, install location, or ffmpeg build.
+_ffmpeg_path = imageio_ffmpeg.get_ffmpeg_exe()
+AudioSegment.converter = _ffmpeg_path
+AudioSegment.ffprobe = _ffmpeg_path  # imageio_ffmpeg bundles no separate ffprobe
 
 def convert_ogg_to_mp3():
     root = tk.Tk()

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ scipy>=1.10.0
 # Audio format conversion (OGG to MP3)
 # Source: audio/convert_ogg_mp3.py
 pydub>=0.25.1
+imageio-ffmpeg>=0.5.0  # bundled ffmpeg binary resolved at runtime via get_ffmpeg_exe()
 
 # =============================================================================
 # IMAGE PROCESSING MODULES

--- a/video/screen_recorder.py
+++ b/video/screen_recorder.py
@@ -27,7 +27,7 @@ from screeninfo import get_monitors
 import mss
 
 # --- CONFIGURATION -------------------------------------------------------
-OUTPUT_DIR = Path("C:/Users/u0150867/Downloads/videos")
+OUTPUT_DIR = Path.home() / "Downloads" / "videos"
 DEFAULT_FPS = 5
 CODEC = cv2.VideoWriter_fourcc(*"mp4v")
 MAX_FILE_MB: int | None = None


### PR DESCRIPTION
## Summary

- **audio/convert_ogg_mp3.py**: replaced hardcoded Python311+v7.1 ffmpeg absolute path with `imageio_ffmpeg.get_ffmpeg_exe()` resolved at runtime; added `imageio-ffmpeg>=0.5.0` to `requirements.txt`.
- **video/screen_recorder.py**: replaced `OUTPUT_DIR = Path("C:/Users/u0150867/Downloads/videos")` (foreign machine profile) with `Path.home() / "Downloads" / "videos"` — the existing `mkdir(parents=True, exist_ok=True)` in `__init__` already handles directory creation.

## Validation

- `py_compile audio/convert_ogg_mp3.py video/screen_recorder.py` — OK
- Runtime probe: `imageio_ffmpeg.get_ffmpeg_exe()` resolves to a real binary (`ffmpeg-win-x86_64-v7.1.exe` inside the venv), `Path.home() / "Downloads" / "videos"` resolves to `C:\Users\rober\Downloads\videos` with no hardcoded user profile.
- `git diff main...HEAD` — exactly 3 files, all in scope.

Closes #48