### PR TITLE
chore: replace hardcoded one-machine paths in audio and screenshot tools

### DIFF
--- a/audio/audio_normalize.py
+++ b/audio/audio_normalize.py
@@ -495,8 +495,12 @@ def main():
         # Check if test mode (no GUI)
         import sys
         if len(sys.argv) > 1 and sys.argv[1] == "--test":
-            # Test mode - use the test.m4a file directly
-            input_path = r"E:\automation\automation\audio\test.m4a"
+            # Test mode - resolve file from argv[2] or env var
+            test_file = (sys.argv[2] if len(sys.argv) > 2 else None) or os.environ.get("AUDIO_NORMALIZE_TEST_FILE")
+            if not test_file:
+                logger.error("❌ TEST MODE: No test file specified. Pass path as argv[2] or set AUDIO_NORMALIZE_TEST_FILE env var.")
+                return
+            input_path = test_file
             logger.info(f"🧪 TEST MODE: Using file: {os.path.basename(input_path)}")
 
             # Step 2: Analyze current levels

--- a/image/screenshot.py
+++ b/image/screenshot.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 from datetime import datetime
+from pathlib import Path
 from mss import mss
 from PIL import Image
 
@@ -45,7 +46,7 @@ def get_bottom_left_monitor(monitors):
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
-    output_folder = "E:\\downloads\\snaps"
+    output_folder = os.environ.get("SCREENSHOT_OUTPUT_FOLDER", str(Path.home() / "Downloads" / "snaps"))
     monitors = list_monitors()
     monitor_index = None
 


### PR DESCRIPTION
## Summary

- **audio/audio_normalize.py:499** — `--test` mode no longer hard-codes `E:\automation\automation\audio\test.m4a`. Reads from `argv[2]` (explicit) first, then `AUDIO_NORMALIZE_TEST_FILE` env var. Fails with a clear error message when neither is provided.
- **image/screenshot.py:48** — `output_folder` no longer hard-codes `E:\downloads\snaps`. Defaults to `Path.home() / "Downloads" / "snaps"` (portable across machines), overridable via `SCREENSHOT_OUTPUT_FOLDER` env var.

These are the two paths that slipped through the #49 sweep because they lived inside `--test` branches and `if __name__ == "__main__":` blocks rather than at module level.

## Validation

- **Syntax gate:** `py -m py_compile audio/audio_normalize.py image/screenshot.py` — OK
- **Behavioral probe (audio):** extracted the new resolution logic and verified: no arg + no env → `None` (error path); `argv[2]` provided → used; env var set → used. All three branches correct.
- **Behavioral probe (screenshot):** default resolves to `C:\Users\rober\Downloads\snaps` (machine-appropriate `Path.home()`); `SCREENSHOT_OUTPUT_FOLDER` env var override respected. No project-level test suite exists (monorepo of standalone scripts).
- **Diff review:** two files, two targeted hunks, nothing outside the stated scope.

Closes #57