### PR TITLE
chore: close claude-md-drift findings across audio/image/notion/system scripts

### DIFF
--- a/audio/audio_extractor_core.py
+++ b/audio/audio_extractor_core.py
@@ -8,10 +8,6 @@ import tkinter as tk
 from tkinter import filedialog, messagebox
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
-)
 logger = logging.getLogger(__name__)
 
 class AudioExtractor:
@@ -271,6 +267,10 @@ class AudioExtractor:
 
 def main():
     """Main function to run the audio extractor."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s'
+    )
     import argparse
     
     parser = argparse.ArgumentParser(description='Extract audio tracks from video files')

--- a/audio/transcript_collate.py
+++ b/audio/transcript_collate.py
@@ -1,5 +1,3 @@
-# source > https://claude.ai/chat/2b85a103-e8ca-448c-ad33-d8888e43654f
-
 import logging
 import os
 import re

--- a/google/setup_helper_script.py
+++ b/google/setup_helper_script.py
@@ -53,32 +53,32 @@ def get_children_info() -> List[Dict[str, str]]:
         List of children dictionaries
     """
     children = []
-    print("\n📝 Child Information")
-    print("-" * 40)
-    
+    log.info("📝 Child Information")
+    log.info("-" * 40)
+
     while True:
-        print(f"\nChild #{len(children) + 1}")
-        
+        log.info("Child #%d", len(children) + 1)
+
         name = input("Enter child's name (or press Enter to finish): ").strip()
         if not name:
             if not children:
-                print("❌ You must add at least one child!")
+                log.warning("❌ You must add at least one child!")
                 continue
             break
-            
+
         while True:
             birth_date = input(f"Enter {name}'s birth date (YYYY-MM-DD): ").strip()
             if validate_date(birth_date):
                 break
-            print("❌ Invalid date format. Please use YYYY-MM-DD")
-            
+            log.warning("❌ Invalid date format. Please use YYYY-MM-DD")
+
         children.append({
             "name": name,
             "birth_date": birth_date
         })
-        
-        print(f"✅ Added {name} (born {birth_date})")
-        
+
+        log.info("✅ Added %s (born %s)", name, birth_date)
+
     return children
 
 
@@ -90,24 +90,24 @@ def get_email_recipients() -> List[str]:
         List of email addresses
     """
     recipients = []
-    print("\n📧 Email Recipients")
-    print("-" * 40)
-    print("Enter email addresses to receive weekly album links")
-    
+    log.info("📧 Email Recipients")
+    log.info("-" * 40)
+    log.info("Enter email addresses to receive weekly album links")
+
     while True:
         email = input(f"Email #{len(recipients) + 1} (or press Enter to finish): ").strip()
         if not email:
             if not recipients:
-                print("❌ You must add at least one recipient!")
+                log.warning("❌ You must add at least one recipient!")
                 continue
             break
-            
+
         if validate_email(email):
             recipients.append(email)
-            print(f"✅ Added {email}")
+            log.info("✅ Added %s", email)
         else:
-            print("❌ Invalid email format. Please try again.")
-            
+            log.warning("❌ Invalid email format. Please try again.")
+
     return recipients
 
 
@@ -120,18 +120,18 @@ def check_credentials_file() -> bool:
     """
     creds_path = Path("credentials.json")
     if creds_path.exists():
-        print("✅ Found credentials.json")
+        log.info("✅ Found credentials.json")
         return True
     else:
-        print("\n⚠️  credentials.json not found!")
-        print("\nTo get your credentials file:")
-        print("1. Go to https://console.cloud.google.com")
-        print("2. Create or select a project")
-        print("3. Enable Google Photos Library API and Gmail API")
-        print("4. Go to APIs & Services > Credentials")
-        print("5. Create OAuth 2.0 Client ID (Desktop application)")
-        print("6. Download the credentials and save as 'credentials.json'")
-        print("\nPlace credentials.json in this directory and run setup again.")
+        log.warning("⚠️  credentials.json not found!")
+        log.info("To get your credentials file:")
+        log.info("1. Go to https://console.cloud.google.com")
+        log.info("2. Create or select a project")
+        log.info("3. Enable Google Photos Library API and Gmail API")
+        log.info("4. Go to APIs & Services > Credentials")
+        log.info("5. Create OAuth 2.0 Client ID (Desktop application)")
+        log.info("6. Download the credentials and save as 'credentials.json'")
+        log.info("Place credentials.json in this directory and run setup again.")
         return False
 
 
@@ -149,41 +149,41 @@ def create_config_file(config: Dict[str, Any]) -> None:
         if backup.lower() == 'y':
             backup_path = Path(f"config.backup.{datetime.now().strftime('%Y%m%d_%H%M%S')}.json")
             config_path.rename(backup_path)
-            print(f"✅ Backup created: {backup_path}")
-            
+            log.info("✅ Backup created: %s", backup_path)
+
     with open(config_path, 'w', encoding='utf-8') as f:
         json.dump(config, f, indent=2, ensure_ascii=False)
-        
-    print(f"\n✅ Configuration saved to config.json")
+
+    log.info("✅ Configuration saved to config.json")
 
 
 def main():
     """Main setup function."""
-    print("=" * 50)
-    print("   Weekly Photo Album Automation Setup")
-    print("=" * 50)
-    
+    log.info("=" * 50)
+    log.info("   Weekly Photo Album Automation Setup")
+    log.info("=" * 50)
+
     # Check for credentials file
     if not check_credentials_file():
-        print("\n❌ Setup cannot continue without credentials.json")
+        log.error("❌ Setup cannot continue without credentials.json")
         input("\nPress Enter to exit...")
         sys.exit(1)
-        
-    print("\nLet's configure your automation settings...")
-    
+
+    log.info("Let's configure your automation settings...")
+
     # Get children information
     children = get_children_info()
-    
+
     # Get email recipients
     recipients = get_email_recipients()
-    
+
     # Get timezone
-    print("\n🌍 Timezone Configuration")
-    print("-" * 40)
-    print("Common timezones:")
-    print("  - US/Eastern, US/Central, US/Pacific")
-    print("  - Europe/London, Europe/Paris, Europe/Madrid")
-    print("  - Asia/Tokyo, Asia/Shanghai, Australia/Sydney")
+    log.info("🌍 Timezone Configuration")
+    log.info("-" * 40)
+    log.info("Common timezones:")
+    log.info("  - US/Eastern, US/Central, US/Pacific")
+    log.info("  - Europe/London, Europe/Paris, Europe/Madrid")
+    log.info("  - Asia/Tokyo, Asia/Shanghai, Australia/Sydney")
     timezone = input("\nEnter your timezone (default: Europe/Madrid): ").strip()
     if not timezone:
         timezone = "Europe/Madrid"
@@ -207,38 +207,38 @@ def main():
     }
     
     # Display summary
-    print("\n" + "=" * 50)
-    print("   Configuration Summary")
-    print("=" * 50)
-    print(f"\n👶 Children ({len(children)}):")
+    log.info("=" * 50)
+    log.info("   Configuration Summary")
+    log.info("=" * 50)
+    log.info("👶 Children (%d):", len(children))
     for child in children:
         birth = datetime.strptime(child['birth_date'], '%Y-%m-%d')
         weeks_old = (datetime.now() - birth).days // 7
-        print(f"  - {child['name']} (born {child['birth_date']}, currently week {weeks_old})")
-        
-    print(f"\n📧 Recipients ({len(recipients)}):")
+        log.info("  - %s (born %s, currently week %d)", child['name'], child['birth_date'], weeks_old)
+
+    log.info("📧 Recipients (%d):", len(recipients))
     for email in recipients:
-        print(f"  - {email}")
-        
-    print(f"\n🌍 Timezone: {timezone}")
-    
+        log.info("  - %s", email)
+
+    log.info("🌍 Timezone: %s", timezone)
+
     # Confirm and save
     confirm = input("\n💾 Save this configuration? (y/n): ")
     if confirm.lower() == 'y':
         create_config_file(config)
-        
-        print("\n" + "=" * 50)
-        print("   Setup Complete!")
-        print("=" * 50)
-        print("\n✅ Your automation is configured and ready to use!")
-        print("\nNext steps:")
-        print("1. Run a test: python weekly_photo_automation.py --dry-run")
-        print("2. Authenticate with Google (browser will open)")
-        print("3. Run the automation: python weekly_photo_automation.py")
-        print("\nFor automated scheduling, see README.md")
+
+        log.info("=" * 50)
+        log.info("   Setup Complete!")
+        log.info("=" * 50)
+        log.info("✅ Your automation is configured and ready to use!")
+        log.info("Next steps:")
+        log.info("1. Run a test: python weekly_photo_automation.py --dry-run")
+        log.info("2. Authenticate with Google (browser will open)")
+        log.info("3. Run the automation: python weekly_photo_automation.py")
+        log.info("For automated scheduling, see README.md")
     else:
-        print("\n❌ Setup cancelled. No changes were made.")
-        
+        log.warning("❌ Setup cancelled. No changes were made.")
+
     input("\nPress Enter to exit...")
 
 

--- a/image/carrousel_pdf_to_jpg.py
+++ b/image/carrousel_pdf_to_jpg.py
@@ -1,10 +1,12 @@
 import logging
 import os
 import sys
-from pdf2image import convert_from_path
 import tkinter as tk
 from tkinter import filedialog
 from tkinter import messagebox
+from typing import List, Tuple
+
+from pdf2image import convert_from_path
 
 log = logging.getLogger(__name__)
 
@@ -15,7 +17,7 @@ HARDCODED_SOURCE_FOLDER = os.getenv("CARROUSEL_SOURCE_FOLDER", "")
 POPPLER_PATH = os.getenv("POPPLER_PATH", "")
 
 
-def find_pdf_files(root_folder):
+def find_pdf_files(root_folder: str) -> List[str]:
     """Recursively find all PDF files in the root folder and its subfolders."""
     pdf_files = []
     for dirpath, _, filenames in os.walk(root_folder):
@@ -25,7 +27,7 @@ def find_pdf_files(root_folder):
     return pdf_files
 
 
-def clean_up_existing_images(folder_path, pdf_name):
+def clean_up_existing_images(folder_path: str, pdf_name: str) -> Tuple[List[str], List[Tuple[str, str]]]:
     """Delete existing JPG images that match the PDF file name and the naming convention in the specified folder."""
     deleted_files = []
     failed_deletions = []
@@ -41,7 +43,7 @@ def clean_up_existing_images(folder_path, pdf_name):
     return deleted_files, failed_deletions
 
 
-def pdf_to_images(pdf_files):
+def pdf_to_images(pdf_files: List[str]) -> None:
     """Convert each PDF file to JPG images, handling errors and logging the process."""
     total_images_created = 0
     total_files_processed = 0
@@ -103,7 +105,7 @@ def pdf_to_images(pdf_files):
             log.warning("- %s: %s", item, error)
 
 
-def select_folder():
+def select_folder() -> str:
     """Open a popup window to select the root folder."""
     root = tk.Tk()
     root.withdraw()  # Hide the root window
@@ -111,7 +113,7 @@ def select_folder():
     return root_folder
 
 
-def main():
+def main() -> None:
     """Main function to execute the PDF to images conversion."""
     root_folder = HARDCODED_SOURCE_FOLDER
 

--- a/image/collage_image.py
+++ b/image/collage_image.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import random
+from typing import List, Tuple
 from PIL import Image
 
 log = logging.getLogger(__name__)
@@ -20,7 +21,7 @@ A4_RATIO = 0.707091103
 output_file = os.path.join(source_folder, "collage_a4.png")
 
 # Function to check and get all PNG images in the folder and its subfolders
-def get_all_images(folder):
+def get_all_images(folder: str) -> List[str]:
     image_list = []
     if not os.path.exists(folder):
         log.error("Error: The folder '%s' does not exist.", folder)
@@ -34,7 +35,7 @@ def get_all_images(folder):
     return image_list
 
 # Function to calculate the optimal grid size for A4 ratio
-def find_best_grid(num_images, max_value, a4_ratio):
+def find_best_grid(num_images: int, max_value: int, a4_ratio: float) -> Tuple[int, int]:
     best_ratio = None
     best_diff = float('inf')
     best_grid = (0, 0)
@@ -54,7 +55,7 @@ def find_best_grid(num_images, max_value, a4_ratio):
     return best_grid
 
 # Function to create the collage
-def create_collage(image_paths, output_file, base_width, base_height, dpi, a4_ratio):
+def create_collage(image_paths: List[str], output_file: str, base_width: int, base_height: int, dpi: int, a4_ratio: float) -> None:
     if len(image_paths) == 0:
         log.error("Error: No PNG images found in the specified folder.")
         return

--- a/image/heic_to_jpg_converter.py
+++ b/image/heic_to_jpg_converter.py
@@ -29,8 +29,6 @@ import os
 from pathlib import Path
 import logging
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 # HEIC Support Registration
@@ -184,6 +182,7 @@ def convert_heic_to_jpg(folder_path: str) -> None:
 
 def main() -> None:
     """Main function to run the HEIC to JPG converter"""
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
     logger.info("📸 HEIC to JPG Converter")
     logger.info("=" * 50)
     logger.info("Converts HEIC/HEIF images to JPG while preserving size and quality")

--- a/image/illustrations_formatter.py
+++ b/image/illustrations_formatter.py
@@ -21,16 +21,17 @@ Key features
   :meth:`IllustrationsFormatter.convert_single_to_1920x1080`.
 """
 
+import argparse
+import json
+import logging
 import os
 import sys
 import time
-import logging
-import argparse
-import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Tuple, List, Optional, Dict, Any
+
 from PIL import Image
-from dataclasses import dataclass
 
 
 @dataclass

--- a/image/illustrations_subscribers.py
+++ b/image/illustrations_subscribers.py
@@ -26,21 +26,23 @@ Options:
     --log-level LEVEL  Logging level (default: INFO)
 """
 
-import os
-import sys
-import json
-import shutil
-import logging
 import argparse
 import glob
+import json
+import logging
+import os
+import shutil
+import sys
 import time
-import pandas as pd
-from PIL import Image
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+from PIL import Image
 
 # Set up logging
-def setup_logging(log_level="INFO"):
+def setup_logging(log_level: str = "INFO") -> logging.Logger:
     """Configure logging with the specified log level."""
     numeric_level = getattr(logging, log_level.upper(), None)
     if not isinstance(numeric_level, int):
@@ -54,7 +56,7 @@ def setup_logging(log_level="INFO"):
     return logging.getLogger(__name__)
 
 # Function to encode a message into an image
-def encode_message(image_path, message, output_path):
+def encode_message(image_path: str, message: str, output_path: str) -> None:
     """
     Encodes a hidden message into an image using LSB steganography.
 
@@ -90,7 +92,7 @@ def encode_message(image_path, message, output_path):
     # Save the image with the encoded message
     encoded_img.save(output_path)
 
-def load_dataframe(file_path, logger, description="file"):
+def load_dataframe(file_path: str, logger: logging.Logger, description: str = "file") -> pd.DataFrame:
     """Load a DataFrame from an Excel file with error handling."""
     while True:
         try:
@@ -107,7 +109,7 @@ def load_dataframe(file_path, logger, description="file"):
             logger.error(f"Error loading {description}: {str(e)}")
             input("Press any key to try again...")
 
-def parse_arguments():
+def parse_arguments() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Process illustrations for subscribers")
     parser.add_argument("--config", type=str, 
@@ -123,7 +125,7 @@ def parse_arguments():
                         help="Logging level")
     return parser.parse_args()
 
-def load_config(config_path, args, logger):
+def load_config(config_path: str, args: argparse.Namespace, logger: logging.Logger) -> Dict[str, Any]:
     """Load configuration from JSON file and override with command-line arguments."""
     try:
         with open(config_path, 'r') as f:
@@ -161,7 +163,7 @@ def load_config(config_path, args, logger):
 
     return config
 
-def process_subscribers(config, logger):
+def process_subscribers(config: Dict[str, Any], logger: logging.Logger) -> None:
     """Main processing function."""
     # Get today's date in the appropriate format
     today_date = datetime.now().date()
@@ -304,7 +306,7 @@ def process_subscribers(config, logger):
     else:
         logger.info("Encoding process skipped.")
 
-def main():
+def main() -> None:
     """Main entry point for the script."""
     args = parse_arguments()
     

--- a/image/image_resizer.py
+++ b/image/image_resizer.py
@@ -8,8 +8,6 @@ import tkinter as tk
 from tkinter import filedialog
 from typing import Optional
 
-# Configure logging to display logs on the console only
-logging.basicConfig(stream=sys.stdout, level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 # Create logger at module level
 logger = logging.getLogger(__name__)
 
@@ -187,6 +185,8 @@ def select_folder_with_tkinter() -> Optional[Path]:
         return None
 
 def main():
+    # Configure logging to display logs on the console only
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
     parser = argparse.ArgumentParser(description="Resize images in a folder to a maximum file size")
     parser.add_argument('--folder', '-f', type=str, help='Path to the folder containing images')
     parser.add_argument('--max-size', '-m', type=float, default=500, 

--- a/image/image_to_pdf_collate.py
+++ b/image/image_to_pdf_collate.py
@@ -10,7 +10,6 @@ import pillow_heif
 
 pillow_heif.register_heif_opener()
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".gif", ".tiff", ".tif", ".webp", ".heic", ".heif"}
@@ -96,6 +95,7 @@ class App(tk.Tk):
 
 
 def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     app = App()
     app.mainloop()
 

--- a/image/photos_archive.py
+++ b/image/photos_archive.py
@@ -14,21 +14,23 @@ Configuration: photos_archive.json (follows AGENTS.md guidelines)
 - date_parsing: Regex patterns for filename date extraction
 """
 
+import hashlib
+import json
+import logging
 import os
 import re
-import json
-import pandas as pd
 import shutil
+import tkinter as tk
 from datetime import datetime, timedelta
+from tkinter import filedialog
+from typing import Any, Dict, Optional
+
+import pandas as pd
 from PIL import Image
 from PIL.ExifTags import TAGS
-import logging
-import hashlib
-import tkinter as tk
-from tkinter import filedialog
 from pymediainfo import MediaInfo
 
-def load_config():
+def load_config() -> Dict[str, Any]:
     """Load and validate configuration from photos_archive.json."""
     config_path = os.path.join(os.path.dirname(__file__), 'photos_archive.json')
     try:
@@ -72,7 +74,7 @@ def load_config():
 # Load configuration
 CONFIG = load_config()
 
-def calculate_time_intervals(df):
+def calculate_time_intervals(df: pd.DataFrame) -> pd.DataFrame:
     """Calculate time intervals between consecutive files within same day."""
     # Extract date part from unified names (YYYYMMDD)
     df['unified_day'] = df['unified_name'].apply(lambda x: x[:8])
@@ -85,7 +87,7 @@ def calculate_time_intervals(df):
 
     return df
 
-def calculate_short_sequence_counts(df, threshold=None):
+def calculate_short_sequence_counts(df: pd.DataFrame, threshold: Optional[int] = None) -> pd.DataFrame:
     """Count files in short sequences per day (below time threshold)."""
     if threshold is None:
         threshold = CONFIG['processing_thresholds']['short_sequence_seconds']
@@ -103,7 +105,7 @@ def calculate_short_sequence_counts(df, threshold=None):
 
     return df
 
-def setup_logging(log_folder=None):
+def setup_logging(log_folder: Optional[str] = None) -> None:
     """Configure logging to timestamped file in specified folder."""
     if log_folder is None:
         log_folder = CONFIG.get('log_folder', CONFIG['destination_folder'])
@@ -127,7 +129,7 @@ def setup_logging(log_folder=None):
     root_logger.addHandler(console_handler)
     logging.info("Logging initialized: %s", log_file)
 
-def get_exif_creation_date(file_path):
+def get_exif_creation_date(file_path: str) -> Optional[datetime]:
     """Extract creation date from EXIF DateTimeOriginal tag."""
     try:
         image = Image.open(file_path)
@@ -156,7 +158,7 @@ def get_exif_creation_date(file_path):
     return None
 
 
-def parse_date(date_str):
+def parse_date(date_str: str) -> Optional[datetime]:
     """
     Parses a date string and returns a datetime object.
 
@@ -175,7 +177,7 @@ def parse_date(date_str):
             logging.warning(f"Unknown date format for video date: {date_str}")
             return None
 
-def extract_date_from_filename(filename):
+def extract_date_from_filename(filename: str) -> Optional[datetime]:
     """Extract date from filename using configured regex patterns."""
     patterns = CONFIG['date_parsing']['filename_patterns']
     for pattern in patterns:
@@ -192,7 +194,7 @@ def extract_date_from_filename(filename):
                 continue
     return None
 
-def get_video_creation_date(file_path):
+def get_video_creation_date(file_path: str) -> Optional[datetime]:
     """Extract creation date from video metadata using pymediainfo."""
     try:
         media_info = MediaInfo.parse(file_path)
@@ -209,7 +211,7 @@ def get_video_creation_date(file_path):
         return None
 
 
-def get_file_info(file_path):
+def get_file_info(file_path: str) -> Optional[Dict[str, Any]]:
     """Extract comprehensive metadata from media file."""
     try:
         file_stat = os.stat(file_path)
@@ -290,7 +292,7 @@ def get_file_info(file_path):
         logging.error(f"Error getting file info for {file_path}: {e}")
         return None
 
-def process_files(source_folder, dest_folder, skip_dest_folder):
+def process_files(source_folder: str, dest_folder: str, skip_dest_folder: bool) -> pd.DataFrame:
     """
     Processes all files in the source folder and its subfolders to extract metadata.
     Optionally excludes files in the destination folder if it's a subfolder of the source folder.
@@ -322,7 +324,7 @@ def process_files(source_folder, dest_folder, skip_dest_folder):
 
     return pd.DataFrame(file_records)
 
-def delete_discarded_files(df):
+def delete_discarded_files(df: pd.DataFrame) -> None:
     """
     Deletes the source files that are marked as discarded in the metadata.
 
@@ -351,7 +353,7 @@ def delete_discarded_files(df):
 
     logging.info("%d discarded files deleted", deleted_files_count)
 
-def calculate_sha256(file_path):
+def calculate_sha256(file_path: str) -> str:
     """
     Calculate the SHA256 hash of a file.
 
@@ -367,7 +369,7 @@ def calculate_sha256(file_path):
             sha256_hash.update(byte_block)
     return sha256_hash.hexdigest()
 
-def mark_duplicates(df):
+def mark_duplicates(df: pd.DataFrame) -> pd.DataFrame:
     """
     Identifies and marks duplicate files in the DataFrame and counts duplicates.
 
@@ -414,7 +416,7 @@ def mark_duplicates(df):
 
     return df
 
-def calculate_total_files_unified_day(df):
+def calculate_total_files_unified_day(df: pd.DataFrame) -> pd.DataFrame:
     """
     Calculates the total number of files with the same unified name in year, month, and day.
 
@@ -428,7 +430,7 @@ def calculate_total_files_unified_day(df):
     df['total_files_unified_day'] = df.groupby('unified_day')['unified_day'].transform('count')
     return df
 
-def recalculate_metadata(df):
+def recalculate_metadata(df: pd.DataFrame) -> pd.DataFrame:
     """
     Recalculates the metadata fields based on the existing file information.
 
@@ -495,7 +497,7 @@ def recalculate_metadata(df):
 
     return df
 
-def copy_files(df):
+def copy_files(df: pd.DataFrame) -> None:
     """
     Copies non-duplicate files to the destination folder, renaming them based on the unified name.
 
@@ -543,7 +545,7 @@ def copy_files(df):
 
     logging.info("%d files copied", copied_files_count)
 
-def delete_copied_files(df):
+def delete_copied_files(df: pd.DataFrame) -> None:
     """
     Deletes the source files that were successfully copied to the destination folder.
 
@@ -571,7 +573,7 @@ def delete_copied_files(df):
     logging.info("%d files deleted", deleted_files_count)
 
 # Call this function at the beginning of your main function
-def main(source_folder, dest_folder):
+def main(source_folder: str, dest_folder: str) -> None:
     # Set up logging to save log file in the destination folder
     current_time_str = datetime.now().strftime('%Y%m%d-%H%M')
     setup_logging(dest_folder)

--- a/image/png_to_jpg_converter.py
+++ b/image/png_to_jpg_converter.py
@@ -5,11 +5,9 @@ import os
 from pathlib import Path
 import logging
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-def select_folder():
+def select_folder() -> str:
     """Open folder dialog and return selected folder path"""
     root = tk.Tk()
     root.withdraw()  # Hide the main window
@@ -21,7 +19,7 @@ def select_folder():
     root.destroy()
     return folder_path
 
-def validate_image_file(file_path):
+def validate_image_file(file_path: Path) -> bool:
     """Validate if a file is a valid image that can be opened"""
     try:
         with Image.open(file_path) as img:
@@ -32,7 +30,7 @@ def validate_image_file(file_path):
         logger.error("Cannot identify image file '%s': %s", file_path, e)
         return False
 
-def convert_png_to_jpg(folder_path):
+def convert_png_to_jpg(folder_path: str) -> None:
     """Convert all PNG images in the folder to JPG format with improved error handling"""
     if not folder_path:
         logger.info("No folder selected.")
@@ -109,8 +107,9 @@ def convert_png_to_jpg(folder_path):
         logger.info("Note: %d files had errors and were skipped.", error_count)
         logger.info("This could be due to corrupted files, unsupported formats, or permission issues.")
 
-def main():
+def main() -> None:
     """Main function to run the PNG to JPG converter"""
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
     logger.info("PNG to JPG Converter (Improved)")
     logger.info("=" * 40)
 

--- a/image/screenshot.py
+++ b/image/screenshot.py
@@ -3,19 +3,26 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import List, Optional
 from mss import mss
 from PIL import Image
 
 log = logging.getLogger(__name__)
 
-def list_monitors():
+def list_monitors() -> List[dict]:
     """List all available monitors and their dimensions."""
     with mss() as sct:
         monitors = sct.monitors  # List of all monitors
     return monitors
 
-def capture_specific_monitor(monitor_index, output_folder="D:\\MwSnap_temporal"):
+def capture_specific_monitor(monitor_index: int, output_folder: Optional[str] = None) -> None:
     """Capture a screenshot of a specific monitor by its index."""
+    # Resolve the output folder from env / home when not supplied explicitly.
+    if output_folder is None:
+        output_folder = os.environ.get(
+            "SCREENSHOT_OUTPUT_FOLDER", str(Path.home() / "Downloads" / "snaps")
+        )
+
     # Create the output folder if it doesn't exist
     if not os.path.exists(output_folder):
         os.makedirs(output_folder)
@@ -40,7 +47,7 @@ def capture_specific_monitor(monitor_index, output_folder="D:\\MwSnap_temporal")
 
     log.info("Screenshot saved to %s", file_path)
 
-def get_bottom_left_monitor(monitors):
+def get_bottom_left_monitor(monitors: List[dict]) -> dict:
     """Find the monitor at the bottom-left position."""
     return min(monitors[1:], key=lambda m: (m["top"], m["left"]))
 

--- a/linkedin/check_ip/config.py
+++ b/linkedin/check_ip/config.py
@@ -6,7 +6,7 @@ Configuration Management Module
 This module handles configuration loading from JSON files and command-line argument parsing
 for the LinkedIn image search application.
 
-Author: Roberto (Refactored by Claude)
+Author: Roberto
 Date: March 2025
 """
 

--- a/linkedin/check_ip/data_processor.py
+++ b/linkedin/check_ip/data_processor.py
@@ -6,7 +6,7 @@ Data Processor Module
 This module handles data processing utilities including date extraction, source identification,
 and duplicate detection for the LinkedIn image search application.
 
-Author: Roberto (Refactored by Claude)
+Author: Roberto
 Date: March 2025
 """
 

--- a/linkedin/check_ip/imgur_client.py
+++ b/linkedin/check_ip/imgur_client.py
@@ -6,7 +6,7 @@ Imgur Client Module
 This module handles image upload operations to Imgur with retry logic and exponential backoff
 for the LinkedIn image search application.
 
-Author: Roberto (Refactored by Claude)
+Author: Roberto
 Date: March 2025
 """
 

--- a/linkedin/check_ip/main.py
+++ b/linkedin/check_ip/main.py
@@ -15,7 +15,7 @@ Features:
 - Time-based processing: Skips images processed within the last N days based on LinkedIn count
 - Configurable search types: Control whether to do exact matches or enable similar matches
 
-Author: Roberto (Refactored by Claude)
+Author: Roberto
 Date: March 2025
 """
 

--- a/linkedin/check_ip/search_client.py
+++ b/linkedin/check_ip/search_client.py
@@ -6,13 +6,14 @@ Search Client Module
 This module handles Google Lens searches via SerpAPI with API history tracking
 for the LinkedIn image search application.
 
-Author: Roberto (Refactored by Claude)
+Author: Roberto
 Date: March 2025
 """
 
 import datetime
 import json
 import logging
+import os
 import pandas as pd
 import requests
 import urllib.parse
@@ -130,7 +131,7 @@ class SearchClient:
                 'page_token': page_token,  # Keep for backward compatibility, will be None for new searches
                 
                 # Additional SerpAPI-specific fields
-                'user': 'roberto.ferraro@gmail.com',  # User email is not in the API response, but we know it
+                'user': os.environ.get("CHECK_IP_OWNER_EMAIL"),  # User email is not in the API response; supplied via env
                 'requester_ip': None,  # Not available in API response
                 'rtt': 1,  # Not available in API response, default to 1
                 'device': 'desktop',  # Not available in API response, default to desktop

--- a/linkedin/check_ip/storage.py
+++ b/linkedin/check_ip/storage.py
@@ -6,7 +6,7 @@ Storage Management Module
 This module handles all file operations including Excel file loading, saving, and data management
 for the LinkedIn image search application.
 
-Author: Roberto (Refactored by Claude)
+Author: Roberto
 Date: March 2025
 """
 

--- a/notion/normalize_names.py
+++ b/notion/normalize_names.py
@@ -17,7 +17,7 @@ import logging
 import os
 import re
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple, Any
 
 import requests
@@ -113,7 +113,7 @@ class NotionNameNormalizer:
     
     def _query_notion_database(self, days: int) -> List[Dict]:
         """Query Notion database for articles created in the last N days."""
-        filter_date = datetime.utcnow() - timedelta(days=days)
+        filter_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
         filter_date_str = filter_date.isoformat() + 'Z'
         
         logging.info(f"🔍 Querying database for articles from last {days} days (since {filter_date_str})")

--- a/notion/normalize_url.py
+++ b/notion/normalize_url.py
@@ -16,7 +16,7 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 
@@ -147,7 +147,7 @@ class NotionURLNormalizer:
 
     def _query_notion_database(self, days: int) -> List[Dict]:
         """Query Notion database for articles created in the last N days."""
-        filter_date = datetime.utcnow() - timedelta(days=days)
+        filter_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
         filter_date_str = filter_date.isoformat() + 'Z'
         
         logging.info(f"🔍 Querying database for articles from last {days} days (since {filter_date_str})")

--- a/notion/notion_databases_add_editorial.py
+++ b/notion/notion_databases_add_editorial.py
@@ -1,470 +1,236 @@
 # Run with repo venv: ..\.venv\Scripts\python notion_databases_add_editorial.py (from this folder), or notion_databases_add_editorial.bat
 
-
-
 import argparse
-
 import logging
-
 import os
-
 import sys
-
 from calendar import monthrange
-
 from datetime import datetime, timedelta
 from typing import Optional
-
 from dotenv import load_dotenv
 from notion_client import Client
-
-
 
 from utils import read_params_from_txt_file, DEFAULT_PARAMS_FILE
 
 
-
-
-
 def setup_logging(debug: bool = False):
-
     """Set up logging configuration (same style as normalize_url.py)."""
-
     sys.stdout.reconfigure(encoding="utf-8")
-
     level = logging.DEBUG if debug else logging.INFO
-
     logging.basicConfig(
-
         level=level,
-
         format="%(asctime)s - %(levelname)s - %(message)s",
-
         handlers=[logging.StreamHandler(sys.stdout)],
-
     )
-
-
-
 
 
 def editorial_date_range(now: Optional[datetime] = None) -> tuple[str, str]:
-
     """
-
     First day of the current calendar month through last day of the next calendar month (YYYY-MM-DD).
-
     """
-
     today = now or datetime.now()
-
     start = datetime(today.year, today.month, 1)
-
     if today.month == 12:
-
         end_year, end_month = today.year + 1, 1
-
     else:
-
         end_year, end_month = today.year, today.month + 1
-
     last_day = monthrange(end_year, end_month)[1]
-
     end = datetime(end_year, end_month, last_day)
-
     fmt = "%Y-%m-%d"
-
     return start.strftime(fmt), end.strftime(fmt)
 
 
-
-
-
 # Initialize Notion Client using parameters file or NOTION_API_TOKEN env var
-
 def init_notion_client(params_file_path, timeout_ms=180_000):
-
     if params_file_path:
-
         params = read_params_from_txt_file(params_file_path)
-
         api_token = params["api_token"]
-
     else:
-
         load_dotenv()
-
         api_token = os.getenv("NOTION_API_TOKEN")
-
         if not api_token:
-
             raise ValueError(
-
                 "No params file configured and NOTION_API_TOKEN is not set. "
-
                 "Set NOTION_PARAMS_FILE or add NOTION_API_TOKEN to .env."
-
             )
-
     # Default SDK timeout is 60s; large DBs or slow links often need more.
-
     return Client(auth=api_token, timeout_ms=timeout_ms)
 
 
-
-
-
 # Format database ID with hyphens
-
 def format_database_id(database_id):
-
     if len(database_id) == 32:
-
         # Insert hyphens to convert into UUID format
-
         return f"{database_id[:8]}-{database_id[8:12]}-{database_id[12:16]}-{database_id[16:20]}-{database_id[20:]}"
-
     return database_id
 
 
-
-
-
 # Check existing records and add missing dates
-
 def add_missing_dates(notion, database_id, start_date, end_date):
-
     # Format for Notion date properties
-
     date_format = "%Y-%m-%d"
-
     day_text_format = "%Y%m%d"
-
     day_of_week_format = "%a"
 
-
-
     # Convert input dates to datetime objects
-
     start = datetime.strptime(start_date, date_format)
-
     end = datetime.strptime(end_date, date_format)
-
-
 
     logging.info(f"📅 Range: {start_date} → {end_date}")
 
-
-
     # Retrieve existing dates in range (filtered query = fewer pages, faster than full scan)
-
     existing_dates = get_existing_dates(notion, database_id, start_date, end_date)
 
-
-
     if existing_dates is None:
-
         logging.error("Could not retrieve existing dates. Check database ID and integration access.")
-
         return
 
-
-
     logging.info(f"📊 Found {len(existing_dates)} existing date(s) in database")
-
     if existing_dates:
-
         sample_dates = sorted(list(existing_dates))[:5]
-
         logging.info(f"Sample existing dates: {sample_dates}")
 
-
-
     # Generate missing date records
-
     new_entries = []
-
     current_date = start
 
-
-
     while current_date <= end:
-
         date_str = current_date.strftime(date_format)  # YYYY-MM-DD format for ISO 8601
-
         if date_str not in existing_dates:
-
             day_text = current_date.strftime(day_text_format)  # YYYYMMDD as text
-
             day_of_week = current_date.strftime(day_of_week_format).lower()
 
-
-
             new_entry = add_date_record(notion, database_id, day_text, date_str, day_of_week)
-
             if new_entry:
-
                 logging.info(
-
                     f"📝 Added: day={day_text}, date={date_str}, DoW={day_of_week}, id={new_entry['id']}"
-
                 )
-
                 new_entries.append(new_entry)
-
         else:
-
             logging.debug(f"Skipping existing date: {date_str}")
-
-
 
         current_date += timedelta(days=1)
 
-
-
     logging.info(f"✅ Total new records added: {len(new_entries)}")
-
     for entry in new_entries:
-
         title = entry["properties"]["day"]["title"][0]["plain_text"]
-
         logging.debug(f"Record ID: {entry['id']}, day: {title}")
 
 
-
-
-
 # Helper: Retrieve existing dates in [range_start, range_end] (YYYY-MM-DD)
-
 def get_existing_dates(notion, database_id, range_start, range_end):
-
     try:
-
         formatted_db_id = format_database_id(database_id)
 
-
-
         # notion-client 2.x removed Client.databases.query; use data_sources.query instead.
-
         database_details = notion.databases.retrieve(formatted_db_id)
-
         data_sources = database_details.get("data_sources") or []
-
         if not data_sources:
-
             logging.error(
-
                 "No data sources on this database (Notion API 2025+). Check integration access."
-
             )
-
             return None
-
         data_source_id = data_sources[0]["id"]
 
-
-
         date_filter = {
-
             "and": [
-
                 {"property": "date", "date": {"on_or_after": range_start}},
-
                 {"property": "date", "date": {"on_or_before": range_end}},
-
             ]
-
         }
 
-
-
         logging.info("Loading database records...")
-
         existing_dates = set()
-
         has_more = True
-
         start_cursor = None
-
         cumulative_count = 0
 
-
-
         while has_more:
-
             response = notion.data_sources.query(
-
                 data_source_id,
-
                 filter=date_filter,
-
                 page_size=100,
-
                 start_cursor=start_cursor,
-
             )
 
-
-
             if response is None or "results" not in response:
-
                 logging.error("No results returned. Check database permissions and structure.")
-
                 return None
 
-
-
             results = response.get("results", [])
-
             start_cursor = response.get("next_cursor")
 
-
-
             records_in_batch = len(results)
-
             cumulative_count += records_in_batch
-
             logging.info(f"📥 Fetched {records_in_batch} records (cumulative: {cumulative_count})")
 
-
-
             for item in results:
-
                 date_property = item["properties"].get("date", {}).get("date")
-
                 if date_property and date_property.get("start"):
-
                     date_value = date_property["start"]
-
                     if "T" in date_value:
-
                         date_value = date_value.split("T")[0]
-
                     existing_dates.add(date_value)
-
-
 
             has_more = start_cursor is not None
 
-
-
         return existing_dates
 
-
-
     except Exception as e:
-
         logging.error(f"Error retrieving existing dates: {e}")
-
         return None
-
-
-
 
 
 # Helper: Add a new record to the Notion database
-
 def add_date_record(notion, database_id, day, date, day_of_week):
-
     try:
-
         formatted_db_id = format_database_id(database_id)
-
         return notion.pages.create(
-
             parent={"database_id": formatted_db_id},
-
             properties={
-
                 "day": {"title": [{"text": {"content": day}}]},
-
                 "date": {"date": {"start": date}},
-
                 "DoW": {"rich_text": [{"text": {"content": day_of_week}}]},
-
             },
-
         )
-
     except Exception as e:
-
         logging.error(f"Error adding record for {date}: {e}")
-
         return None
 
 
-
-
-
 def main():
-
     parser = argparse.ArgumentParser(
-
         description="Add missing editorial calendar rows for the current and next calendar month."
-
     )
-
     parser.add_argument(
-
         "--params",
-
         type=str,
-
         default=DEFAULT_PARAMS_FILE,
-
         help="Path to notion-params.txt (api_token)",
-
     )
-
     parser.add_argument(
-
         "--database-id",
-
         type=str,
-
         default="ee23dec3222e4412baaf0d129d0bda9c",
-
         help="Notion database ID (32-char or UUID)",
-
     )
-
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
 
-
-
     args = parser.parse_args()
-
     setup_logging(args.debug)
 
-
-
     start_date, end_date = editorial_date_range()
-
     logging.info("✅ Editorial DB sync starting (current month + next month)")
 
-
-
     try:
-
         notion = init_notion_client(args.params)
-
         add_missing_dates(notion, args.database_id, start_date, end_date)
-
     except Exception as e:
-
         logging.error(f"❌ Fatal error: {e}")
-
         if args.debug:
-
             logging.exception("Full traceback:")
-
         sys.exit(1)
 
 
-
-
-
 if __name__ == "__main__":
-
     main()
-

--- a/notion/notion_databases_clean.py
+++ b/notion/notion_databases_clean.py
@@ -181,25 +181,28 @@ def process_databases(databases_to_process, metadata):
 
         log.info("✅ Processed database '%s' saved to %s with %d rows", database['name'], output_path, len(df))
 
-# Main execution
+def main():
+    params_file_path = DEFAULT_PARAMS_FILE
+    log.info("📂 Loading parameters...")
+    params = read_params_from_txt_file(params_file_path)
+    log.info("✅ Parameters loaded")
 
-params_file_path = DEFAULT_PARAMS_FILE
-log.info("📂 Loading parameters...")
-params = read_params_from_txt_file(params_file_path)
-log.info("✅ Parameters loaded")
+    excel_path = params['excel_path']
+    dump_path = params['dump_path']
+    verbose = params['verbose'] == "True"  # Ensure this is checked correctly
 
-excel_path = params['excel_path']
-dump_path = params['dump_path']
-verbose = params['verbose'] == "True"  # Ensure this is checked correctly
+    metadata_path = params['metadata_path']
+    metadata = load_metadata(metadata_path)
+    log.info("✅ Metadata loaded")
 
-metadata_path = params['metadata_path']
-metadata = load_metadata(metadata_path)
-log.info("✅ Metadata loaded")
+    log.info("📋 Reading database list...")
+    databases_to_process = read_database_list(excel_path)
+    log.info("📊 Found %d databases to process", len(databases_to_process))
 
-log.info("📋 Reading database list...")
-databases_to_process = read_database_list(excel_path)
-log.info("📊 Found %d databases to process", len(databases_to_process))
+    log.info("🚀 Starting database cleaning...")
+    process_databases(databases_to_process, metadata)
+    log.info("✅ All database cleaning completed")
 
-log.info("🚀 Starting database cleaning...")
-process_databases(databases_to_process, metadata)
-log.info("✅ All database cleaning completed")
+
+if __name__ == "__main__":
+    main()

--- a/notion/notion_databases_dump.py
+++ b/notion/notion_databases_dump.py
@@ -14,9 +14,6 @@ from utils import read_params_from_txt_file, DEFAULT_PARAMS_FILE
 from utils import get_column_widths
 from utils import apply_column_widths
 
-# sources:
-# 2023-08-08 > https://chat.openai.com/c/18520141-8212-42e8-97aa-09f5de9713f2
-
 # Function to update the last_download and n_rows columns in the Excel file
 def update_last_download_in_excel(database, excel_path, n_rows, output_path):
     # Read the existing Excel file
@@ -141,31 +138,34 @@ def read_database_list(excel_path):
     df = pd.read_excel(excel_path)
     return df[df["ind_download"] == 1]
 
-# Main execution
+def main():
+    # Load the parameters from the text file
+    params_file_path = DEFAULT_PARAMS_FILE
+    log.info("📂 Loading parameters...")
+    params = read_params_from_txt_file(params_file_path)
+    log.info("✅ Parameters loaded")
 
-# Load the parameters from the text file
-params_file_path = DEFAULT_PARAMS_FILE
-log.info("📂 Loading parameters...")
-params = read_params_from_txt_file(params_file_path)
-log.info("✅ Parameters loaded")
+    # Get the api_token
+    api_token = params['api_token']
 
-# Get the api_token
-api_token = params['api_token']
+    # Set the Excel file path and the dump path
+    excel_path = params['excel_path']
+    dump_path = params['dump_path']
 
-# Set the Excel file path and the dump path
-excel_path = params['excel_path']
-dump_path = params['dump_path']
+    # Read the database list from the Excel file and filter the rows with "download = 1"
+    log.info("📋 Reading database list...")
+    databases_to_download = read_database_list(excel_path)
+    log.info("📊 Found %d databases to download", len(databases_to_download))
 
-# Read the database list from the Excel file and filter the rows with "download = 1"
-log.info("📋 Reading database list...")
-databases_to_download = read_database_list(excel_path)
-log.info("📊 Found %d databases to download", len(databases_to_download))
+    # Download the data for each selected database
+    log.info("🚀 Starting database downloads...")
+    for _, database in databases_to_download.iterrows():
+        output_path = download_database_data(database, dump_path, api_token, excel_path)
+    log.info("✅ All database downloads completed")
 
-# Download the data for each selected database
-log.info("🚀 Starting database downloads...")
-for _, database in databases_to_download.iterrows():
-    output_path = download_database_data(database, dump_path, api_token, excel_path)
-log.info("✅ All database downloads completed")
+
+if __name__ == "__main__":
+    main()
 
 
 

--- a/notion/notion_databases_editorial.py
+++ b/notion/notion_databases_editorial.py
@@ -63,14 +63,12 @@ def editorial_databases(databases_to_editorial):
 
         log.info("Processed database '%s' saved to %s as the sheet %s", database['name'], editorial_excel_path, editorial_name)
 
-# Main execution
+if __name__ == "__main__":
+    params_file_path = DEFAULT_PARAMS_FILE
+    params = read_params_from_txt_file(params_file_path)
 
-params_file_path = DEFAULT_PARAMS_FILE
-params = read_params_from_txt_file(params_file_path)
+    excel_path = params['excel_path']
+    editorial_excel_path = params['editorial_excel_path']
 
-excel_path = params['excel_path']
-editorial_excel_path = params['editorial_excel_path']
-
-# this part is from here "notion-09-pass-to-editorial" > https://chat.openai.com/c/1279d9a7-829a-4e0d-a608-e75252e501d3
-databases_to_editorial = read_database_editorial(excel_path)
-editorial_databases(databases_to_editorial)
+    databases_to_editorial = read_database_editorial(excel_path)
+    editorial_databases(databases_to_editorial)

--- a/notion/notion_databases_query.py
+++ b/notion/notion_databases_query.py
@@ -26,24 +26,23 @@ def save_to_excel(databases, db_excel_path):
     df = pd.DataFrame(databases, columns=["name", "id", "url"])
     df.to_excel(db_excel_path, index=False, engine='openpyxl')
 
-# Main execution
-
-# Load the parameters from the text file
-params_file_path = DEFAULT_PARAMS_FILE
-params = read_params_from_txt_file(params_file_path)
-
-# Get the api_token
-api_token = params['api_token']
-
-# Authenticate
-notion = Client(auth=api_token)
-
-# Get the Excel file path and the Notion workspace URL
-db_excel_path = params['db_excel_path']
-workspace_url = params['workspace_url']
-
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    # Load the parameters from the text file
+    params_file_path = DEFAULT_PARAMS_FILE
+    params = read_params_from_txt_file(params_file_path)
+
+    # Get the api_token
+    api_token = params['api_token']
+
+    # Authenticate
+    notion = Client(auth=api_token)
+
+    # Get the Excel file path and the Notion workspace URL
+    db_excel_path = params['db_excel_path']
+    workspace_url = params['workspace_url']
+
     databases = get_database_list()
     save_to_excel(databases, db_excel_path)
     log.info("Databases saved to %s", db_excel_path)

--- a/notion/notion_excel_sync.py
+++ b/notion/notion_excel_sync.py
@@ -3,124 +3,127 @@ import pandas as pd
 from notion_client import Client, APIResponseError
 from utils import read_params_from_txt_file, DEFAULT_PARAMS_FILE
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
-# chatGPT source > https://chat.openai.com/c/4db5a8e0-1344-4fb7-8952-d96607a88b9e
-# chatGPT source > https://chat.openai.com/c/2bfb9ae6-233d-46fe-8171-69e7e1929866
-# chatGPT source > https://chat.openai.com/c/025bb803-a79e-4be1-851f-fbb249db6e38
 
-params_file_path = DEFAULT_PARAMS_FILE
-params = read_params_from_txt_file(params_file_path)
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-sync_path = params['sync_path']
-api_token = params['api_token']
-verbose = params['verbose'] == 'True'
+    params_file_path = DEFAULT_PARAMS_FILE
+    params = read_params_from_txt_file(params_file_path)
 
-log.info("Loading Excel file...")
-xlsx = pd.ExcelFile(sync_path)
+    sync_path = params['sync_path']
+    api_token = params['api_token']
+    verbose = params['verbose'] == 'True'
 
-# Load the data, metadata and db sheets
-df = pd.read_excel(xlsx, 'data')
-metadata_df = pd.read_excel(xlsx, 'metadata')
-db_df = pd.read_excel(xlsx, 'db')
+    log.info("Loading Excel file...")
+    xlsx = pd.ExcelFile(sync_path)
 
-# Extract the Notion database ID
-notion_db_id = db_df.loc[0, 'id']
+    # Load the data, metadata and db sheets
+    df = pd.read_excel(xlsx, 'data')
+    metadata_df = pd.read_excel(xlsx, 'metadata')
+    db_df = pd.read_excel(xlsx, 'db')
 
-# Extract the clean flag
-clean_db = db_df.loc[0, 'clean']
+    # Extract the Notion database ID
+    notion_db_id = db_df.loc[0, 'id']
 
-# Generate a dictionary from the metadata
-metadata_dict = metadata_df.set_index('excelColumn')[['notionColumn', 'type', 'keep']].T.to_dict()
+    # Extract the clean flag
+    clean_db = db_df.loc[0, 'clean']
 
-log.info("Initializing Notion client...")
-client = Client(auth=api_token)
+    # Generate a dictionary from the metadata
+    metadata_dict = metadata_df.set_index('excelColumn')[['notionColumn', 'type', 'keep']].T.to_dict()
 
-# Step 1: Fetch Notion database details
-try:
-    database_details = client.databases.retrieve(notion_db_id)
-    database_name = database_details['title'][0]['text']['content']
+    log.info("Initializing Notion client...")
+    client = Client(auth=api_token)
 
-    # Now, query the database to get the number of rows (pages), paginating fully
-    total_rows = 0
-    start_cursor = None
-    while True:
-        page = client.databases.query(notion_db_id, start_cursor=start_cursor)
-        total_rows += len(page['results'])
-        if not page.get('has_more'):
-            break
-        start_cursor = page.get('next_cursor')
-
-    log.info("Database Name: %s", database_name)
-    log.info("Total Rows in Notion: %d", total_rows)
-
-except APIResponseError as e:
-    log.error("Failed to fetch database details: %s", e)
-
-# Step 2: Ask for confirmation to proceed
-input("Press Enter to continue...")
-
-# Initialize counters
-archived_pages_counter = 0
-created_pages_counter = 0
-
-# If clean flag is True, archive all pages in the database
-if clean_db:
-    log.info("Archiving all pages in the Notion database...")
+    # Step 1: Fetch Notion database details
     try:
-        # Collect every page id first (paginating via next_cursor); archiving
-        # mutates the query result set, so gather ids before archiving to avoid
-        # skipping pages that shift out of later pages.
-        page_ids = []
+        database_details = client.databases.retrieve(notion_db_id)
+        database_name = database_details['title'][0]['text']['content']
+
+        # Now, query the database to get the number of rows (pages), paginating fully
+        total_rows = 0
         start_cursor = None
         while True:
-            response = client.databases.query(notion_db_id, start_cursor=start_cursor)
-            page_ids.extend(page['id'] for page in response['results'])
-            if not response.get('has_more'):
+            page = client.databases.query(notion_db_id, start_cursor=start_cursor)
+            total_rows += len(page['results'])
+            if not page.get('has_more'):
                 break
-            start_cursor = response.get('next_cursor')
+            start_cursor = page.get('next_cursor')
 
-        for page_id in page_ids:
-            # archived is a top-level page field in the Notion API, not a property
-            client.pages.update(page_id, archived=True)
-            archived_pages_counter += 1
-            log.info("Archiving page with ID: %s. Total archived pages: %d", page_id, archived_pages_counter)
+        log.info("Database Name: %s", database_name)
+        log.info("Total Rows in Notion: %d", total_rows)
+
     except APIResponseError as e:
-        log.error("Failed to archive pages: %s", e)
+        log.error("Failed to fetch database details: %s", e)
 
-log.info("Creating all pages in the Excel database...")
-for index, row in df.iterrows():
-    page_data = {"parent": {"database_id": notion_db_id}, "properties": {}}
+    # Step 2: Ask for confirmation to proceed
+    input("Press Enter to continue...")
 
-    for col in df.columns:
-        # Skip column if it doesn't exist in metadata_dict or if 'keep' value is False
-        if col not in metadata_dict or not metadata_dict[col]['keep'] or pd.isnull(row[col]):
-            continue
+    # Initialize counters
+    archived_pages_counter = 0
+    created_pages_counter = 0
 
-        notion_col = metadata_dict[col]['notionColumn']
-        datatype = metadata_dict[col]['type']
+    # If clean flag is True, archive all pages in the database
+    if clean_db:
+        log.info("Archiving all pages in the Notion database...")
+        try:
+            # Collect every page id first (paginating via next_cursor); archiving
+            # mutates the query result set, so gather ids before archiving to avoid
+            # skipping pages that shift out of later pages.
+            page_ids = []
+            start_cursor = None
+            while True:
+                response = client.databases.query(notion_db_id, start_cursor=start_cursor)
+                page_ids.extend(page['id'] for page in response['results'])
+                if not response.get('has_more'):
+                    break
+                start_cursor = response.get('next_cursor')
 
-        if datatype == 'title':
-            page_data["properties"][notion_col] = {"title": [{"text": {"content": str(row[col])}}]}
-        elif datatype == 'date':
-            page_data["properties"][notion_col] = {"date": {"start": row[col].strftime('%Y-%m-%d')}}
-        elif datatype == 'number':
-            page_data["properties"][notion_col] = {"number": row[col]}
-        elif datatype == 'url':
-            page_data["properties"][notion_col] = {"url": str(row[col])}
-        elif datatype == 'relation':
-            related_page_ids = str(row[col]).split(',')
-            page_data["properties"][notion_col] = {"relation": [{"id": page_id.strip()} for page_id in related_page_ids]}
-        elif datatype == 'rich_text':
-            page_data["properties"][notion_col] = {"rich_text": [{"text": {"content": str(row[col])}}]}
-        elif datatype == 'checkbox':
-            page_data["properties"][notion_col] = {"checkbox": bool(row[col])}
+            for page_id in page_ids:
+                # archived is a top-level page field in the Notion API, not a property
+                client.pages.update(page_id, archived=True)
+                archived_pages_counter += 1
+                log.info("Archiving page with ID: %s. Total archived pages: %d", page_id, archived_pages_counter)
+        except APIResponseError as e:
+            log.error("Failed to archive pages: %s", e)
 
-    try:
-        if verbose == True: log.debug("Creating new page with data: %s", page_data)
-        new_page = client.pages.create(**page_data)
-        created_pages_counter += 1
-        log.info("Created new page with ID: %s. Total created pages: %d", new_page['id'], created_pages_counter)
-    except APIResponseError as e:
-        log.error("Failed to create new page: %s", e)
+    log.info("Creating all pages in the Excel database...")
+    for index, row in df.iterrows():
+        page_data = {"parent": {"database_id": notion_db_id}, "properties": {}}
+
+        for col in df.columns:
+            # Skip column if it doesn't exist in metadata_dict or if 'keep' value is False
+            if col not in metadata_dict or not metadata_dict[col]['keep'] or pd.isnull(row[col]):
+                continue
+
+            notion_col = metadata_dict[col]['notionColumn']
+            datatype = metadata_dict[col]['type']
+
+            if datatype == 'title':
+                page_data["properties"][notion_col] = {"title": [{"text": {"content": str(row[col])}}]}
+            elif datatype == 'date':
+                page_data["properties"][notion_col] = {"date": {"start": row[col].strftime('%Y-%m-%d')}}
+            elif datatype == 'number':
+                page_data["properties"][notion_col] = {"number": row[col]}
+            elif datatype == 'url':
+                page_data["properties"][notion_col] = {"url": str(row[col])}
+            elif datatype == 'relation':
+                related_page_ids = str(row[col]).split(',')
+                page_data["properties"][notion_col] = {"relation": [{"id": page_id.strip()} for page_id in related_page_ids]}
+            elif datatype == 'rich_text':
+                page_data["properties"][notion_col] = {"rich_text": [{"text": {"content": str(row[col])}}]}
+            elif datatype == 'checkbox':
+                page_data["properties"][notion_col] = {"checkbox": bool(row[col])}
+
+        try:
+            if verbose == True: log.debug("Creating new page with data: %s", page_data)
+            new_page = client.pages.create(**page_data)
+            created_pages_counter += 1
+            log.info("Created new page with ID: %s. Total created pages: %d", new_page['id'], created_pages_counter)
+        except APIResponseError as e:
+            log.error("Failed to create new page: %s", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/notion/utils.py
+++ b/notion/utils.py
@@ -14,12 +14,13 @@ from datetime import datetime
 from zipfile import BadZipFile
 import json
 from dotenv import load_dotenv
+from typing import Optional, Dict, List, Any
 
 log = logging.getLogger(__name__)
 
 
 # Custom function to replace special characters
-def replace_special_chars(path):
+def replace_special_chars(path: str) -> str:
     special_char_mapping = {
         '%E1': 'á',
         '%E9': 'é',
@@ -42,7 +43,7 @@ def replace_special_chars(path):
     return path
 
 # Function to get the path of the foreground windows explorer
-def get_first_explorer_hwnd():
+def get_first_explorer_hwnd() -> Optional[int]:
     # Get a list of all open windows
     windows = []
     win32gui.EnumWindows(lambda hwnd, windows: windows.append(hwnd), windows)
@@ -56,7 +57,7 @@ def get_first_explorer_hwnd():
 
     return None
 
-def get_explorer_path_from_hwnd(target_hwnd):
+def get_explorer_path_from_hwnd(target_hwnd: int) -> Optional[str]:
     # Get all instances of Shell Windows
     shell_windows = win32com.client.Dispatch("Shell.Application").Windows()
 
@@ -82,7 +83,7 @@ def get_explorer_path_from_hwnd(target_hwnd):
     log.warning("No matching Windows Explorer instance found.")
     return None
 
-def get_first_explorer_folder_path():
+def get_first_explorer_folder_path() -> Optional[str]:
     # Get the HWND of the first Windows Explorer instance with a path in its title
     first_explorer_hwnd = get_first_explorer_hwnd()
 
@@ -106,7 +107,7 @@ def get_first_explorer_folder_path():
 DEFAULT_PARAMS_FILE = os.getenv("NOTION_PARAMS_FILE", "")
 
 # Function to read the parameters from the txt file (legacy support)
-def read_params_from_txt_file(file_path):
+def read_params_from_txt_file(file_path: str) -> Dict[str, str]:
     params = {}
     with open(file_path, 'r') as f:
         for line in f:
@@ -116,7 +117,7 @@ def read_params_from_txt_file(file_path):
     return params
 
 # Function to load JSON configuration file
-def load_json_config(config_path):
+def load_json_config(config_path: str) -> Dict[str, Any]:
     """
     Load configuration from a JSON file.
 
@@ -139,7 +140,7 @@ def load_json_config(config_path):
         raise
 
 # Function to load environment variables from .env file
-def load_env_variables(env_path=None):
+def load_env_variables(env_path: Optional[str] = None) -> Dict[str, Optional[str]]:
     """
     Load environment variables from .env file.
 
@@ -164,7 +165,13 @@ def load_env_variables(env_path=None):
     return env_vars
 
 # Function to open an excel file or a pickle, if found. If not found, creates the pickle
-def read_excel_or_pickle(excel_file_path, pickle_file_path, sheet_name=None, usecols=None, engine=None):
+def read_excel_or_pickle(
+    excel_file_path: str,
+    pickle_file_path: str,
+    sheet_name: Optional[str] = None,
+    usecols: Optional[Any] = None,
+    engine: Optional[str] = None,
+) -> pd.DataFrame:
     excel_file = Path(excel_file_path)
     pickle_file = Path(pickle_file_path)
 
@@ -194,7 +201,7 @@ def read_excel_or_pickle(excel_file_path, pickle_file_path, sheet_name=None, use
     return df
 
 # Get the column widths from the existing Excel file, initializing column_widths as an empty list first
-def get_column_widths(excel_path):
+def get_column_widths(excel_path: str) -> List[Any]:
     column_widths = []
     if not os.path.exists(excel_path):
         log.warning("No existing workbook at %s; skipping column width reuse.", excel_path)
@@ -218,7 +225,7 @@ def get_column_widths(excel_path):
     return column_widths
 
 # Apply column widths to an excel file (requires the column_widths)
-def apply_column_widths(excel_path, column_widths):
+def apply_column_widths(excel_path: str, column_widths: List[Any]) -> None:
     if column_widths:
         wb_final = openpyxl.load_workbook(excel_path)
         ws_final = wb_final.active
@@ -226,7 +233,7 @@ def apply_column_widths(excel_path, column_widths):
             ws_final.column_dimensions[openpyxl.utils.get_column_letter(i+1)].width = width
         wb_final.save(excel_path)
 
-def load_excel_with_json(excel_path, column_name):
+def load_excel_with_json(excel_path: str, column_name: str) -> None:
     # Read the Excel file using the openpyxl engine
     df = pd.read_excel(excel_path, engine="openpyxl")
 
@@ -242,7 +249,7 @@ def load_excel_with_json(excel_path, column_name):
     # Log the resulting DataFrame head
     log.debug("%s", df.head())
 
-def load_excel_with_json_and_export(excel_path, column_name):
+def load_excel_with_json_and_export(excel_path: str, column_name: str) -> None:
     # Read the Excel file using the openpyxl engine
     df = pd.read_excel(excel_path, engine="openpyxl")
 

--- a/system/background.py
+++ b/system/background.py
@@ -1,8 +1,13 @@
 import ctypes
-import winreg as reg
+import logging
 import sys
+import winreg as reg
 
-def set_colors(theme="light grey"):
+log = logging.getLogger(__name__)
+
+
+def set_colors(theme: str = "light grey") -> None:
+    log.info("Applying '%s' desktop theme", theme)
     if theme.lower() == "black":
         rgb_color = (0, 0, 0)
         accent_color = 0x000000
@@ -35,11 +40,15 @@ def set_colors(theme="light grey"):
     reg.CloseKey(key)
 
     ctypes.windll.user32.SystemParametersInfoW(20, 0, "", 1)
+    log.info("Desktop and taskbar colors updated")
 
-def main():
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     # Set default theme to "light grey" if no argument is provided
     theme = sys.argv[1] if len(sys.argv) > 1 else "light grey"
     set_colors(theme)
+
 
 if __name__ == "__main__":
     main()

--- a/system/keycaster.py
+++ b/system/keycaster.py
@@ -3,16 +3,17 @@ import pygetwindow as gw
 import threading
 import time
 import keyboard
+from typing import Optional, Any
 
 # ---------- helper functions ----------
-def find_chrome_window():
+def find_chrome_window() -> Optional[Any]:
     """Return the last active Chrome window or None."""
     for w in gw.getAllWindows():
         if "Google Chrome" in w.title and not w.isMinimized:
             return w
     return None
 
-def type_text(text, delay, stop_event, status_callback):
+def type_text(text: str, delay: float, stop_event: threading.Event, status_callback: Any) -> None:
     for i, char in enumerate(text):
         if stop_event.is_set():
             status_callback(f"Stopped at {i}/{len(text)} chars.")
@@ -24,7 +25,7 @@ def type_text(text, delay, stop_event, status_callback):
     status_callback("Done!")
 
 # ---------- GUI ----------
-def main():
+def main() -> None:
     """Build the KeyCaster window and run its event loop."""
     layout = [
         [sg.Text("Text to “type-paste”:")],

--- a/system/quickdeck/quickdeck.py
+++ b/system/quickdeck/quickdeck.py
@@ -1194,9 +1194,9 @@ def main():
         app = QuickDeck(args.config)
         app.run()
     except KeyboardInterrupt:
-        print("\n👋 QuickDeck stopped by user")
+        logger.info("👋 QuickDeck stopped by user")
     except Exception as e:
-        print(f"❌ Fatal error: {e}")
+        logger.error("❌ Fatal error: %s", e)
         sys.exit(1)
 
 

--- a/system/rename_files.py
+++ b/system/rename_files.py
@@ -5,7 +5,7 @@ import re
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
-def rename_files_in_directory(directory):
+def rename_files_in_directory(directory: str) -> None:
     """
     Traverse through the given directory and its subdirectories,
     rename files by removing the 'v01', 'v02', ... 'vXX' pattern from the file names,
@@ -47,6 +47,7 @@ def rename_files_in_directory(directory):
             log.info("  %s", skipped_file)
 
 
-# Request the directory path from the user
-directory_path = input('Enter the directory path: ')
-rename_files_in_directory(directory_path)
+if __name__ == "__main__":
+    # Request the directory path from the user
+    directory_path = input('Enter the directory path: ')
+    rename_files_in_directory(directory_path)

--- a/system/treesize/treesize.py
+++ b/system/treesize/treesize.py
@@ -10,15 +10,16 @@ import ctypes
 import sys
 import platform
 import subprocess                 # NEW
+from typing import Any, List
 
 # --- NEW: Analyzer class for logic ---
 class TreeSizeAnalyzer:
-    def __init__(self):
+    def __init__(self) -> None:
         self.folder_sizes = {}      # Cache for folder sizes
         self.folder_disk_sizes = {} # Cache for folder disk sizes
         self.file_cache = {}        # Cache for file listings
 
-    def get_folder_size_deep(self, path):
+    def get_folder_size_deep(self, path: str) -> int:
         if path in self.folder_sizes:
             return self.folder_sizes[path]
         total_size = 0
@@ -41,7 +42,7 @@ class TreeSizeAnalyzer:
         self.folder_sizes[path] = total_size
         return total_size
 
-    def get_folder_disk_size_deep(self, path):
+    def get_folder_disk_size_deep(self, path: str) -> int:
         if path in self.folder_disk_sizes:
             return self.folder_disk_sizes[path]
         total_size = 0
@@ -64,7 +65,7 @@ class TreeSizeAnalyzer:
         self.folder_disk_sizes[path] = total_size
         return total_size
 
-    def get_space_on_disk(self, path):
+    def get_space_on_disk(self, path: str) -> int:
         if not os.path.exists(path):
             return 0
         if platform.system() == 'Windows':
@@ -97,7 +98,7 @@ class TreeSizeAnalyzer:
             logging.debug(f"GetCompressedFileSizeW failed for {path}: {e}")
             return None
 
-    def get_cluster_size(self, path):
+    def get_cluster_size(self, path: str) -> int:
         try:
             if platform.system() == 'Windows':
                 return 4096
@@ -105,7 +106,7 @@ class TreeSizeAnalyzer:
             pass
         return 4096
 
-    def get_folder_size_shallow(self, path):
+    def get_folder_size_shallow(self, path: str) -> int:
         total_size = 0
         try:
             for item in os.listdir(path):
@@ -120,7 +121,7 @@ class TreeSizeAnalyzer:
                 logging.warning(f"Error calculating shallow size for {path}: {e}")
         return total_size
 
-    def format_size(self, size):
+    def format_size(self, size: int) -> str:
         for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
             if size < 1024.0:
                 return f"{size:.2f} {unit}"
@@ -129,13 +130,13 @@ class TreeSizeAnalyzer:
 
 # Configure logging
 class TextHandler(logging.Handler):
-    def __init__(self, text_widget):
+    def __init__(self, text_widget: Any) -> None:
         logging.Handler.__init__(self)
         self.text_widget = text_widget
-        
-    def emit(self, record):
+
+    def emit(self, record: logging.LogRecord) -> None:
         msg = self.format(record)
-        def append():
+        def append() -> None:
             self.text_widget.configure(state='normal')
             self.text_widget.insert(tk.END, msg + '\n')
             self.text_widget.configure(state='disabled')
@@ -149,7 +150,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 class TreeSizeApp:
-    def __init__(self, root):
+    def __init__(self, root: tk.Tk) -> None:
         self.root = root
         self.root.title("TreeSize - Folder Size Analyzer")
         self.root.geometry("900x700")  # Made taller to accommodate log area
@@ -164,7 +165,7 @@ class TreeSizeApp:
         
         self.setup_ui()
         
-    def setup_ui(self):
+    def setup_ui(self) -> None:
         # --- style / theme -------------------------------------------------
         style = ttk.Style()
         try:
@@ -287,7 +288,7 @@ class TreeSizeApp:
         ttk.Button(control_frame, text="Open Folder", command=self.open_selected_folder).pack(side=tk.RIGHT, padx=5)         # NEW
         ttk.Button(control_frame, text="Open File Location", command=self.open_selected_file_location).pack(side=tk.RIGHT)    # NEW
         
-    def on_metric_change(self):
+    def on_metric_change(self) -> None:
         """Handle change in size metric selection"""
         metric = self.size_metric.get()
         logger.info(f"Size metric changed to: {metric}")
@@ -303,7 +304,7 @@ class TreeSizeApp:
             # Update displayed sizes for visible items
             self.update_displayed_sizes()
             
-    def update_displayed_sizes(self):
+    def update_displayed_sizes(self) -> None:
         """Update all displayed sizes based on the current metric"""
         # Update folder tree
         for item in self.folder_tree.get_children(""):
@@ -326,7 +327,7 @@ class TreeSizeApp:
         for top in self.folder_tree.get_children(""):     # NEW – resort each branch
             self._sort_tree_by_size(top)
             
-    def update_item_sizes(self, item):
+    def update_item_sizes(self, item: str) -> None:
         """Update size display for a single tree item"""
         item_data = self.folder_tree.item(item)
         path = item_data['values'][1]
@@ -339,7 +340,7 @@ class TreeSizeApp:
             size_str = self.analyzer.format_size(size)
             self.folder_tree.set(item, "size", size_str)
             
-    def get_folder_size(self, path):
+    def get_folder_size(self, path: str) -> int:
         """Get folder size based on selected metric"""
         metric = self.size_metric.get()
         if metric == "actual":
@@ -347,7 +348,7 @@ class TreeSizeApp:
         else:
             return self.analyzer.get_folder_disk_size_deep(path)
             
-    def select_folder(self):
+    def select_folder(self) -> None:
         folder = filedialog.askdirectory()
         if folder:
             logger.info(f"Selected folder: {folder}")
@@ -356,7 +357,7 @@ class TreeSizeApp:
             self.folder_tree.delete(*self.folder_tree.get_children())
             self.load_folder_contents(folder, parent="")
             
-    def load_folder_contents(self, path, parent=""):
+    def load_folder_contents(self, path: str, parent: str = "") -> None:
         """Load only the immediate contents of a folder"""
         logger.debug(f"Loading contents of: {path}")
         self.status_bar.config(text=f"Loading: {os.path.basename(path) or path}")
@@ -366,7 +367,7 @@ class TreeSizeApp:
         thread.daemon = True
         thread.start()
         
-    def _load_folder_thread(self, path, parent):
+    def _load_folder_thread(self, path: str, parent: str) -> None:
         start_time = datetime.now()
         try:
             items = []
@@ -397,7 +398,7 @@ class TreeSizeApp:
             logger.error(f"Error loading folder {path}: {e}")
             self.root.after(0, lambda: self.status_bar.config(text=f"Error: {str(e)}"))
             
-    def _update_folder_tree(self, items, parent, parent_path):
+    def _update_folder_tree(self, items: List[Any], parent: str, parent_path: str) -> None:
         nodes = []
         for name, size, path, is_dir in items:
             size_str = self.analyzer.format_size(size) if size > 0 else "Calculating..."
@@ -435,7 +436,7 @@ class TreeSizeApp:
             # If all sizes already calculated, sort nodes by size
             self._sort_tree_by_size(parent)
         
-    def _calculate_and_update_size(self, node, folder_path, parent):
+    def _calculate_and_update_size(self, node: str, folder_path: str, parent: str) -> None:
         """Calculate folder size and update the tree"""
         try:
             start = datetime.now()
@@ -448,7 +449,7 @@ class TreeSizeApp:
             self.root.after(100, lambda: self._sort_tree_by_size(parent))
             
             # --- NEW : finished-batch detection ---
-            def _maybe_done():
+            def _maybe_done() -> bool:
                 for child in self.folder_tree.get_children(parent):
                     val = self.folder_tree.item(child, "values")[0]
                     if val in ("Calculating...", "Error"):
@@ -465,7 +466,7 @@ class TreeSizeApp:
             logger.error(f"Error calculating size for {folder_path}: {e}")
             self.root.after(0, lambda: self.folder_tree.set(node, "size", "Error"))
     
-    def _sort_tree_by_size(self, parent):
+    def _sort_tree_by_size(self, parent: str) -> None:
         """Sort folders by size in descending order"""
         items = self.folder_tree.get_children(parent)
         if not items:
@@ -496,7 +497,7 @@ class TreeSizeApp:
         for idx, (item, _) in enumerate(item_list):
             self.folder_tree.move(item, parent, idx)
     
-    def load_top_files(self, folder_path):
+    def load_top_files(self, folder_path: str) -> None:
         # Check if we have cached results
         if folder_path in self.analyzer.file_cache:
             logger.info(f"Using cached file list for {folder_path}")
@@ -510,7 +511,7 @@ class TreeSizeApp:
         thread.daemon = True
         thread.start()
         
-    def _load_files_thread(self, folder_path):
+    def _load_files_thread(self, folder_path: str) -> None:
         start_time = datetime.now()
         try:
             files = []
@@ -553,7 +554,7 @@ class TreeSizeApp:
             logger.error(f"Error loading files from {folder_path}: {e}")
             self.root.after(0, lambda: self.status_bar.config(text=f"Error: {str(e)}"))
             
-    def _update_file_tree(self, files):
+    def _update_file_tree(self, files: List[Any]) -> None:
         self.file_tree.delete(*self.file_tree.get_children())
         for filename, size, full_path in files:             # CHANGED – keep full path
             size_str = self.analyzer.format_size(size)
@@ -561,7 +562,7 @@ class TreeSizeApp:
         self.status_bar.config(text="Ready")
         
     # ---------- NEW METHODS ----------
-    def refresh(self):
+    def refresh(self) -> None:
         """Clear caches and reload current folder."""
         if not self.current_path:
             messagebox.showinfo("Refresh", "No folder selected.")
@@ -574,7 +575,7 @@ class TreeSizeApp:
         self.file_tree.delete(*self.file_tree.get_children())
         self.load_folder_contents(self.current_path, parent="")
 
-    def open_selected_folder(self):
+    def open_selected_folder(self) -> None:
         """Open highlighted folder in system file explorer."""
         sel = self.folder_tree.selection()
         if not sel:
@@ -591,7 +592,7 @@ class TreeSizeApp:
         else:
             subprocess.run(['xdg-open', path], check=False)
 
-    def open_selected_file_location(self):
+    def open_selected_file_location(self) -> None:
         """Reveal selected file in explorer / finder."""
         sel = self.file_tree.selection()
         if not sel:
@@ -611,7 +612,7 @@ class TreeSizeApp:
             subprocess.run(['xdg-open', os.path.dirname(path)], check=False)
     # ---------- END NEW METHODS ----------
 
-    def on_folder_expand(self, event):
+    def on_folder_expand(self, event: Any) -> None:
         """Handle folder expansion - load subfolders if not already loaded"""
         item = self.folder_tree.focus()
         if not item:
@@ -632,7 +633,7 @@ class TreeSizeApp:
             # Load contents
             self.load_folder_contents(folder_path, item)
 
-    def on_folder_select(self, event):
+    def on_folder_select(self, event: Any) -> None:
         selection = self.folder_tree.selection()
         if selection:
             item = self.folder_tree.item(selection[0])
@@ -642,7 +643,7 @@ class TreeSizeApp:
                     logger.debug(f"Selected folder: {folder_path}")
                     self.load_top_files(folder_path)
 
-def main():
+def main() -> None:
     root = tk.Tk()
     app = TreeSizeApp(root)
     root.mainloop()

--- a/system/venv_manager.py
+++ b/system/venv_manager.py
@@ -50,20 +50,20 @@ def get_venv_info():
 
 def deactivate_venv():
     """Provide instructions to deactivate the virtual environment."""
-    print("\nTo deactivate the virtual environment, you need to:")
+    log.info("To deactivate the virtual environment, you need to:")
     if os.name == 'nt':  # Windows
-        print("1. Close this script")
-        print("2. Run 'deactivate' in your command prompt")
-        print("3. Make sure to run 'python' and not the VENV python when restarting")
-        print("\nTIP: If deactivation doesn't work, try running this script with:")
-        print(f"   {os.path.join(sys.base_prefix, 'python')} {os.path.basename(__file__)}")
+        log.info("1. Close this script")
+        log.info("2. Run 'deactivate' in your command prompt")
+        log.info("3. Make sure to run 'python' and not the VENV python when restarting")
+        log.info("TIP: If deactivation doesn't work, try running this script with:")
+        log.info("   %s %s", os.path.join(sys.base_prefix, 'python'), os.path.basename(__file__))
     else:  # Unix/Linux/Mac
-        print("1. Close this script")
-        print("2. Run 'deactivate' in your terminal")
-        print("3. Make sure to run 'python' and not the VENV python when restarting")
-        print("\nTIP: If deactivation doesn't work, try running this script with:")
-        print(f"   {os.path.join(sys.base_prefix, 'bin/python')} {os.path.basename(__file__)}")
-    
+        log.info("1. Close this script")
+        log.info("2. Run 'deactivate' in your terminal")
+        log.info("3. Make sure to run 'python' and not the VENV python when restarting")
+        log.info("TIP: If deactivation doesn't work, try running this script with:")
+        log.info("   %s %s", os.path.join(sys.base_prefix, 'bin/python'), os.path.basename(__file__))
+
     sys.exit("Please restart this script after deactivating the virtual environment.")
 
 def get_installed_packages():
@@ -152,88 +152,88 @@ def clean_environment(packages_to_keep=None):
     installed_packages = get_installed_packages()
     count = 0
     failed = 0
-    
-    print(f"\nFound {len(installed_packages)} installed packages")
-    print(f"Will keep: {', '.join(packages_to_keep)}")
-    
+
+    log.info("Found %d installed packages", len(installed_packages))
+    log.info("Will keep: %s", ', '.join(packages_to_keep))
+
     # Check if running as admin for global Python installations
     if not is_in_virtualenv() and not is_admin():
-        print("\n⚠️  WARNING: You are not running with administrator privileges.")
-        print("You may encounter permission errors when uninstalling packages from a global Python installation.")
-        print("Options:")
-        print("  1. Restart this script with administrator privileges (recommended)")
-        print("  2. Use a virtual environment instead")
-        print("  3. Continue anyway (some uninstalls may fail)")
-        
+        log.warning("WARNING: You are not running with administrator privileges.")
+        log.warning("You may encounter permission errors when uninstalling packages from a global Python installation.")
+        log.info("Options:")
+        log.info("  1. Restart this script with administrator privileges (recommended)")
+        log.info("  2. Use a virtual environment instead")
+        log.info("  3. Continue anyway (some uninstalls may fail)")
+
         choice = input("\nHow would you like to proceed? (1/2/3): ")
-        
+
         if choice == '1':
             # Attempt to re-launch with elevated privileges
             elevate_privileges()
             # If we get here, elevation failed
-            print("Failed to restart with administrator privileges.")
+            log.error("Failed to restart with administrator privileges.")
             proceed = input("Continue anyway? (y/n): ")
             if proceed.lower() != 'y':
                 return
         elif choice == '2':
-            print("\nCreating a virtual environment is recommended. Steps:")
-            print("1. Run: python -m venv .venv")
-            print("2. Activate it: .venv\\Scripts\\activate (Windows) or source .venv/bin/activate (Unix)")
-            print("3. Install only the packages you need in the virtual environment")
+            log.info("Creating a virtual environment is recommended. Steps:")
+            log.info("1. Run: python -m venv .venv")
+            log.info("2. Activate it: .venv\\Scripts\\activate (Windows) or source .venv/bin/activate (Unix)")
+            log.info("3. Install only the packages you need in the virtual environment")
             sys.exit("Please create a virtual environment and try again.")
-    
-    print("\nPackages to be uninstalled:")
-    
+
+    log.info("Packages to be uninstalled:")
+
     packages_to_uninstall = []
-    
+
     for package_line in installed_packages:
         package_name = package_line.split('==')[0]
         if package_name.lower() not in [pkg.lower() for pkg in packages_to_keep]:
-            print(f"  - {package_name}")
+            log.info("  - %s", package_name)
             packages_to_uninstall.append(package_name)
-    
+
     if not packages_to_uninstall:
-        print("No packages to uninstall!")
+        log.info("No packages to uninstall!")
         return
-    
+
     # Ask for confirmation
     confirm = input("\nAre you sure you want to uninstall these packages? (y/n): ")
     if confirm.lower() != 'y':
-        print("Operation cancelled.")
+        log.info("Operation cancelled.")
         return
-    
+
     # Uninstall packages
-    print("\nUninstalling packages...")
-    
+    log.info("Uninstalling packages...")
+
     results = []
     for package in packages_to_uninstall:
-        print(f"Uninstalling {package}...")
+        log.info("Uninstalling %s...", package)
         success, message = safe_uninstall_package(package)
-        
+
         if success:
             count += 1
-            print(f"  ✓ {message}")
+            log.info("  ✓ %s", message)
         else:
             failed += 1
-            print(f"  ✗ {message}")
-        
+            log.warning("  ✗ %s", message)
+
         results.append((package, success, message))
-    
-    print(f"\nCompleted! Uninstalled {count} packages successfully.")
-    
+
+    log.info("Completed! Uninstalled %d packages successfully.", count)
+
     if failed > 0:
-        print(f"\n{failed} packages failed to uninstall. Summary of failures:")
+        log.warning("%d packages failed to uninstall. Summary of failures:", failed)
         for package, success, message in results:
             if not success:
-                print(f"  - {package}: {message}")
-        
-        print("\nTroubleshooting tips:")
-        print("1. Run this script with administrator privileges")
-        print("2. Try uninstalling problematic packages manually: pip uninstall <package>")
-        print("3. Consider using a virtual environment instead of modifying your global Python")
-        
+                log.warning("  - %s: %s", package, message)
+
+        log.info("Troubleshooting tips:")
+        log.info("1. Run this script with administrator privileges")
+        log.info("2. Try uninstalling problematic packages manually: pip uninstall <package>")
+        log.info("3. Consider using a virtual environment instead of modifying your global Python")
+
     if count > 0:
-        print("\nYour environment has been cleaned up!")
+        log.info("Your environment has been cleaned up!")
 
 def main():
     """Main function to run the VENV manager."""
@@ -242,54 +242,59 @@ def main():
         elevate_privileges()
     
     # Display script banner
-    print("\n" + "="*50)
-    print("Python Virtual Environment Manager")
-    print("="*50)
-    
+    log.info("=" * 50)
+    log.info("Python Virtual Environment Manager")
+    log.info("=" * 50)
+
     venv_info = get_venv_info()
-    
-    print("\n" + "="*50)
-    print(f"Current Python Environment: {venv_info['name']}")
-    print(f"Status: {'VIRTUAL ENVIRONMENT' if venv_info['status'] == 'active' else 'GLOBAL PYTHON'}")
-    print(f"Path: {venv_info['path']}")
-    print(f"Python Executable: {venv_info['executable']}")
-    print("="*50 + "\n")
-    
+
+    log.info("=" * 50)
+    log.info("Current Python Environment: %s", venv_info['name'])
+    log.info("Status: %s", 'VIRTUAL ENVIRONMENT' if venv_info['status'] == 'active' else 'GLOBAL PYTHON')
+    log.info("Path: %s", venv_info['path'])
+    log.info("Python Executable: %s", venv_info['executable'])
+    log.info("=" * 50)
+
     if venv_info['status'] == 'active':
-        print("You are currently in a virtual environment.")
+        log.info("You are currently in a virtual environment.")
         choice = input("Do you want to deactivate it before proceeding (y) or force continue (f)? (y/f/n): ")
         if choice.lower() == 'y':
             deactivate_venv()
         elif choice.lower() == 'f':
-            print("\nForcing continuation despite being in a virtual environment...")
+            log.info("Forcing continuation despite being in a virtual environment...")
         else:
-            print("\nContinuing in the virtual environment...")
-    
+            log.info("Continuing in the virtual environment...")
+
     # Show installed packages
     packages = get_installed_packages()
-    print(f"\nYou have {len(packages)} package(s) installed:")
-    
+    log.info("You have %d package(s) installed:", len(packages))
+
     # Display packages in columns (optional condensed view)
+    row = []
     for i, pkg_line in enumerate(packages):
         pkg_name = pkg_line.split('==')[0]
-        print(f"{pkg_name:25}", end="\t" if (i+1) % 3 != 0 else "\n")
-    print("\n" if len(packages) % 3 != 0 else "")
-    
+        row.append(f"{pkg_name:25}")
+        if (i + 1) % 3 == 0:
+            log.info("\t".join(row))
+            row = []
+    if row:
+        log.info("\t".join(row))
+
     # Ask if user wants to clean the environment
     choice = input("Do you want to clean this environment (remove unnecessary packages)? (y/n): ")
     if choice.lower() == 'y':
         # Define packages to keep
         essential_packages = ['pip', 'setuptools', 'wheel']
-        
+
         # Ask for additional packages to keep
         user_kept_packages = input("\nEnter any additional packages to keep (comma-separated) or press Enter to continue: ")
         if user_kept_packages.strip():
             additional_packages = [pkg.strip() for pkg in user_kept_packages.split(',')]
             essential_packages.extend(additional_packages)
-        
+
         clean_environment(essential_packages)
-    
-    print("\nThank you for using the VENV Manager!")
+
+    log.info("Thank you for using the VENV Manager!")
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")

--- a/system/wifi/wifi_connect.py
+++ b/system/wifi/wifi_connect.py
@@ -6,7 +6,7 @@ import xml.etree.ElementTree as ET
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
-def connect_to_wifi():
+def connect_to_wifi() -> None:
     try:
         # Get the path to the current folder where the script is located
         script_directory = os.path.dirname(os.path.abspath(__file__))
@@ -72,5 +72,5 @@ def connect_to_wifi():
     except Exception as e:
         log.error("Error: %s", e)
 
-# Example usage
-connect_to_wifi()
+if __name__ == "__main__":
+    connect_to_wifi()

--- a/text/clean_sensitive_data.py
+++ b/text/clean_sensitive_data.py
@@ -120,15 +120,14 @@ class CLIDataCleaner(DataCleanerBase):
     
     def interactive_mode(self):
         """Run in interactive CLI mode"""
-        print("=== Sensitive Data Cleaner (CLI Mode) ===")
-        print("Enter text to clean (press Ctrl+D or Ctrl+Z when finished):")
-        print("Type 'config' to change cleaning options, 'quit' to exit")
-        
+        log.info("=== Sensitive Data Cleaner (CLI Mode) ===")
+        log.info("Enter text to clean (press Ctrl+D or Ctrl+Z when finished):")
+        log.info("Type 'config' to change cleaning options, 'quit' to exit")
+
         while True:
             try:
-                print("\n> ", end="")
-                command = input().strip().lower()
-                
+                command = input("\n> ").strip().lower()
+
                 if command == 'quit':
                     break
                 elif command == 'config':
@@ -137,12 +136,12 @@ class CLIDataCleaner(DataCleanerBase):
                 elif command == 'help':
                     self.show_help()
                     continue
-                
+
                 # If it's not a command, treat as text to clean
                 if command:
                     # Read multiline input
                     lines = [command]
-                    print("Continue entering text (empty line to finish):")
+                    log.info("Continue entering text (empty line to finish):")
                     while True:
                         try:
                             line = input()
@@ -151,15 +150,15 @@ class CLIDataCleaner(DataCleanerBase):
                             lines.append(line)
                         except EOFError:
                             break
-                    
+
                     text = '\n'.join(lines)
                     cleaned = self.clean_sensitive_data(text)
-                    print("\n--- Cleaned Text ---")
-                    print(cleaned)
-                    print("--- End ---\n")
-                
+                    log.info("--- Cleaned Text ---")
+                    log.info(cleaned)
+                    log.info("--- End ---")
+
             except (EOFError, KeyboardInterrupt):
-                print("\nExiting...")
+                log.info("Exiting...")
                 break
     
     def configure_options(self):
@@ -175,39 +174,39 @@ class CLIDataCleaner(DataCleanerBase):
             ('clean_guids', 'GUIDs/UUIDs')
         ]
         
-        print("\nCurrent cleaning options:")
+        log.info("Current cleaning options:")
         for i, (attr, name) in enumerate(options, 1):
             status = "ON" if getattr(self, attr) else "OFF"
-            print(f"{i}. {name}: {status}")
-        
-        print("\nEnter option number to toggle (1-8), or press Enter to finish:")
+            log.info("%d. %s: %s", i, name, status)
+
+        log.info("Enter option number to toggle (1-8), or press Enter to finish:")
         while True:
             try:
                 choice = input("> ").strip()
                 if not choice:
                     break
-                
+
                 num = int(choice)
                 if 1 <= num <= len(options):
                     attr, name = options[num - 1]
                     current_value = getattr(self, attr)
                     setattr(self, attr, not current_value)
                     new_status = "ON" if not current_value else "OFF"
-                    print(f"{name} is now {new_status}")
+                    log.info("%s is now %s", name, new_status)
                 else:
-                    print("Invalid option number")
+                    log.warning("Invalid option number")
             except ValueError:
-                print("Please enter a valid number")
+                log.warning("Please enter a valid number")
             except (EOFError, KeyboardInterrupt):
                 break
-    
+
     def show_help(self):
         """Show help information"""
-        print("\nAvailable commands:")
-        print("  config - Configure cleaning options")
-        print("  help   - Show this help")
-        print("  quit   - Exit the program")
-        print("\nOr enter text to clean it according to current settings")
+        log.info("Available commands:")
+        log.info("  config - Configure cleaning options")
+        log.info("  help   - Show this help")
+        log.info("  quit   - Exit the program")
+        log.info("Or enter text to clean it according to current settings")
     
     def clean_file(self, input_path, output_path=None):
         """Clean a file and optionally save to output file"""
@@ -222,9 +221,9 @@ class CLIDataCleaner(DataCleanerBase):
                     f.write(cleaned)
                 log.info("Cleaned text saved to: %s", output_path)
             else:
-                print("--- Cleaned Text ---")
-                print(cleaned)
-                print("--- End ---")
+                log.info("--- Cleaned Text ---")
+                log.info(cleaned)
+                log.info("--- End ---")
         
         except FileNotFoundError:
             log.error("Error: File not found: %s", input_path)
@@ -473,4 +472,5 @@ def main():
         cli_cleaner.interactive_mode()
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     main()


### PR DESCRIPTION
## Summary
- Fix hardcoded paths (env-sourced email, resolved default output dir) and add type hints across audio, image, notion, and system scripts
- Convert print statements to logging and move module-level `logging.basicConfig` calls into `main()`
- Add missing `if __name__ == "__main__":` guards so modules are import-safe
- Strip leftover AI-attribution headers and dead source-provenance URLs (mirrors PR #54)
- Fix import ordering (stdlib -> third-party -> local)
- Replace deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`
- Collapse doubled blank lines in `notion/notion_databases_add_editorial.py`

## Test plan
- [x] `git show --name-only` confirms diff matches the issue's finding categories (spot-checked each category against the diff)
- [x] `python -m py_compile` on all 36 changed files — passes with no errors
- [ ] No automated test suite or CI exists for this repo; verification is limited to byte-compilation

Closes #66