### PR TITLE
refactor: extract shared helpers to resolve duplication findings (#64)

### DIFF
--- a/audio/audio_extractor_core.py
+++ b/audio/audio_extractor_core.py
@@ -4,25 +4,22 @@ import json
 import logging
 from pathlib import Path
 from typing import List, Dict, Optional
-import tkinter as tk
-from tkinter import filedialog, messagebox
 
 # Configure logging
 logger = logging.getLogger(__name__)
 
 class AudioExtractor:
     """Extracts audio tracks from video files using FFmpeg."""
-    
+
     def __init__(self, input_directory: str = None):
         """Initialize the audio extractor.
-        
+
         Args:
             input_directory: Directory containing video files. Defaults to current directory.
         """
         self.input_directory = Path(input_directory) if input_directory else Path.cwd()
         self.supported_formats = {'.mkv', '.mp4'}
-        self.supported_extensions = [('Video files', '*.mkv *.mp4'), ('All files', '*.*')]
-        
+
     def check_ffmpeg(self) -> bool:
         """Check if FFmpeg and FFprobe are available."""
         try:
@@ -206,64 +203,6 @@ class AudioExtractor:
                 continue
         
         logger.info("Processing complete")
-    
-    def select_files_gui(self) -> List[Path]:
-        """Open a GUI dialog to select video files.
-        
-        Returns:
-            List of selected video file paths.
-        """
-        root = tk.Tk()
-        root.withdraw()
-        
-        file_paths = filedialog.askopenfilenames(
-            title="Select video files to extract audio",
-            filetypes=self.supported_extensions,
-            initialdir=self.input_directory
-        )
-        
-        root.destroy()
-        
-        selected_files = []
-        for file_path in file_paths:
-            path = Path(file_path)
-            if path.suffix.lower() in self.supported_formats:
-                selected_files.append(path)
-            else:
-                logger.warning(f"Skipping unsupported file: {path}")
-        
-        return selected_files
-    
-    def process_selected_files(self, video_files: List[Path]) -> None:
-        """Process a list of selected video files.
-        
-        Args:
-            video_files: List of video file paths to process.
-        """
-        if not self.check_ffmpeg():
-            return
-        
-        if not video_files:
-            logger.warning("No video files selected")
-            return
-        
-        logger.info(f"Processing {len(video_files)} selected file(s)")
-        
-        for video_file in video_files:
-            try:
-                self.process_video_file(video_file)
-            except Exception as e:
-                logger.error(f"Unexpected error processing {video_file.name}: {e}")
-                continue
-        
-        logger.info("Processing complete")
-        
-        root = tk.Tk()
-        root.withdraw()
-        messagebox.showinfo("Processing Complete", 
-                          f"Successfully processed {len(video_files)} file(s).\n"
-                          "Check the console for detailed information.")
-        root.destroy()
 
 def main():
     """Main function to run the audio extractor."""
@@ -283,21 +222,23 @@ def main():
     parser.add_argument(
         '--gui', '-g',
         action='store_true',
-        help='Use GUI file selector to choose files manually'
+        help='Launch the full GUI application (audio_extractor_gui.py) to choose files manually'
     )
-    
+
     args = parser.parse_args()
-    
-    extractor = AudioExtractor(args.directory)
-    
+
     if args.gui:
-        selected_files = extractor.select_files_gui()
-        if selected_files:
-            extractor.process_selected_files(selected_files)
-        else:
-            logger.info("No files selected")
-    else:
-        extractor.process_directory()
+        # Route to the full-featured audio_extractor_gui.py (threaded
+        # processing, progress bar, log panel) instead of re-implementing an
+        # ad-hoc file-picker + completion popup here (dedup: audit issue #64).
+        # Deferred import: audio_extractor_gui imports AudioExtractor from
+        # this module, so importing it at module level would be circular.
+        import audio_extractor_gui
+        audio_extractor_gui.main()
+        return
+
+    extractor = AudioExtractor(args.directory)
+    extractor.process_directory()
 
 if __name__ == '__main__':
     main()

--- a/google/_auth.py
+++ b/google/_auth.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Shared Google OAuth + config-loading helpers.
+
+Consolidates logic that was independently duplicated in
+gmail_drive_automation.py and weekly_photo_automation.py: the config
+JSON loader and the load-token / refresh / re-authenticate / save-token
+dance (audit issue #64). Each caller still builds its own set of API
+services from the returned credentials, since that varies by script.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+logger = logging.getLogger(__name__)
+
+
+def load_config(config_path: str, script_dir: Path) -> Dict[str, Any]:
+    """Load configuration from a JSON file, resolving a relative path against script_dir."""
+    logger.debug("📂 Loading configuration file")
+
+    if Path(config_path).is_absolute():
+        config_full_path = Path(config_path)
+    else:
+        config_full_path = script_dir / config_path
+
+    if not config_full_path.exists():
+        logger.error(f"❌ Error: Configuration file not found at {config_full_path}")
+        raise FileNotFoundError(f"Configuration file not found: {config_full_path}")
+
+    try:
+        with open(config_full_path, 'r', encoding='utf-8') as f:
+            config = json.load(f)
+        logger.info("✅ Configuration loaded successfully")
+        return config
+    except json.JSONDecodeError as e:
+        logger.error(f"❌ Error: Invalid JSON in configuration file: {e}")
+        raise
+
+
+def authenticate(config: Dict[str, Any], script_dir: Path, scopes: List[str]) -> Credentials:
+    """Load/refresh/create OAuth credentials for the given scopes.
+
+    Resolves token_file/credentials_file from config['auth'] (relative paths
+    resolved against script_dir), tries to load + refresh an existing token,
+    and falls back to the interactive InstalledAppFlow when there's no valid
+    token. Persists the (possibly new) token before returning.
+    """
+    creds = None
+
+    token_path = Path(config['auth']['token_file'])
+    if not token_path.is_absolute():
+        token_path = script_dir / token_path
+
+    credentials_path = Path(config['auth']['credentials_file'])
+    if not credentials_path.is_absolute():
+        credentials_path = script_dir / credentials_path
+
+    # Load existing token
+    if token_path.exists():
+        creds = Credentials.from_authorized_user_file(str(token_path), scopes)
+        # Refresh credentials to ensure they're valid
+        try:
+            creds.refresh(Request())
+            logger.info("🔄 Credentials refreshed successfully")
+        except Exception as e:
+            logger.warning(f"⚠️ Failed to refresh credentials: {e}")
+            creds = None
+
+    # If there are no (valid) credentials, let the user log in
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            logger.info("🔄 Refreshing expired credentials")
+            creds.refresh(Request())
+        else:
+            logger.info("🔑 Requesting new authentication")
+            flow = InstalledAppFlow.from_client_secrets_file(
+                str(credentials_path), scopes
+            )
+            creds = flow.run_local_server(
+                port=0,
+                access_type="offline",  # get a refresh token
+                prompt="consent",  # force the consent screen, don't reuse old grant
+                include_granted_scopes=False  # don't merge with an older, narrower grant
+            )
+            # force a fresh access token right now
+            creds.refresh(Request())
+            logger.info(f"Granted scopes from token: {creds.scopes}")
+
+        # Save credentials for next run
+        with open(token_path, 'w') as token:
+            token.write(creds.to_json())
+
+    return creds

--- a/google/gmail_drive_automation.py
+++ b/google/gmail_drive_automation.py
@@ -6,7 +6,6 @@ Automatically creates and maintains a Google Sheets file with email data.
 
 # Standard library imports
 import argparse
-import json
 import logging
 import os
 import sys
@@ -15,12 +14,11 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 
 # Third-party library imports
-from google.auth.transport.requests import Request
-from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 import pytz
+
+import _auth
 
 # Configure logging
 logging.basicConfig(
@@ -50,105 +48,36 @@ class GmailDriveAutomation:
     def load_config(self, config_path: str) -> Dict[str, Any]:
         """
         Load configuration from JSON file.
-        
+
         Args:
             config_path: Path to configuration file
-            
+
         Returns:
             Configuration dictionary
         """
-        logger.debug("📂 Loading configuration file")
-        
-        # Get the script directory and resolve config path relative to it
-        script_dir = Path(__file__).parent
-        if Path(config_path).is_absolute():
-            config_full_path = Path(config_path)
-        else:
-            config_full_path = script_dir / config_path
-            
-        if not config_full_path.exists():
-            logger.error(f"❌ Error: Configuration file not found at {config_full_path}")
-            raise FileNotFoundError(f"Configuration file not found: {config_full_path}")
-        
-        try:
-            with open(config_full_path, 'r', encoding='utf-8') as e:
-                config = json.load(e)
-            logger.info("✅ Configuration loaded successfully")
-            return config
-        except json.JSONDecodeError as e:
-            logger.error(f"❌ Error: Invalid JSON in configuration file: {e}")
-            raise
-            
+        return _auth.load_config(config_path, Path(__file__).parent)
+
     def authenticate_google_services(self) -> None:
         """Authenticate with Google Drive, Gmail, and Sheets APIs."""
         logger.info("🔐 Authenticating with Google services")
-        
+
         SCOPES = [
             # Drive API - Core scopes
             'https://www.googleapis.com/auth/drive',
             'https://www.googleapis.com/auth/drive.file',
-            
+
             # Gmail API - Core scopes
             'https://www.googleapis.com/auth/gmail.readonly',
             'https://www.googleapis.com/auth/gmail.metadata',
-            
+
             # Sheets API - Core scopes
             'https://www.googleapis.com/auth/spreadsheets',
             'https://www.googleapis.com/auth/spreadsheets.readonly'
         ]
-        
-        creds = None
-        
-        # Get the script directory and resolve paths relative to it
-        script_dir = Path(__file__).parent
-        
-        # Handle token file path
-        token_path = Path(self.config['auth']['token_file'])
-        if not token_path.is_absolute():
-            token_path = script_dir / token_path
-            
-        # Handle credentials file path
-        credentials_path = Path(self.config['auth']['credentials_file'])
-        if not credentials_path.is_absolute():
-            credentials_path = script_dir / credentials_path
-        
-        # Load existing token
-        if token_path.exists():
-            creds = Credentials.from_authorized_user_file(str(token_path), SCOPES)
-            # Refresh credentials to ensure they're valid
-            try:
-                creds.refresh(Request())
-                logger.info("🔄 Credentials refreshed successfully")
-            except Exception as e:
-                logger.warning(f"⚠️ Failed to refresh credentials: {e}")
-                creds = None
-            
-        # If there are no (valid) credentials, let the user log in
-        if not creds or not creds.valid:
-            if creds and creds.expired and creds.refresh_token:
-                logger.info("🔄 Refreshing expired credentials")
-                creds.refresh(Request())
-            else:
-                logger.info("🔑 Requesting new authentication")
-                flow = InstalledAppFlow.from_client_secrets_file(
-                    str(credentials_path), SCOPES
-                )
-                creds = flow.run_local_server(
-                    port=0,
-                    access_type="offline",  # get a refresh token
-                    prompt="consent",  # force the consent screen, don't reuse old grant
-                    include_granted_scopes=False  # don't merge with an older, narrower grant
-                )
-                # force a fresh access token right now
-                creds.refresh(Request())
-                logger.info(f"Granted scopes from token: {creds.scopes}")
-                
-            # Save credentials for next run
-            with open(token_path, 'w') as token:
-                token.write(creds.to_json())
-                
+
+        creds = _auth.authenticate(self.config, Path(__file__).parent, SCOPES)
         self.credentials = creds
-        
+
         # Build Google Drive API service
         try:
             self.drive_service = build('drive', 'v3', credentials=creds)
@@ -522,33 +451,14 @@ class GmailDriveAutomation:
 def load_config(config_path: str = "config.json") -> Dict[str, Any]:
     """
     Load configuration from JSON file.
-    
+
     Args:
         config_path: Path to configuration file
-        
+
     Returns:
         Configuration dictionary
     """
-    logger.debug("📂 Loading configuration file")
-    
-    script_dir = Path(__file__).parent
-    if Path(config_path).is_absolute():
-        config_full_path = Path(config_path)
-    else:
-        config_full_path = script_dir / config_path
-        
-    if not config_full_path.exists():
-        logger.error(f"❌ Error: Configuration file not found at {config_full_path}")
-        raise FileNotFoundError(f"Configuration file not found: {config_full_path}")
-    
-    try:
-        with open(config_full_path, 'r', encoding='utf-8') as e:
-            config = json.load(e)
-        logger.info("✅ Configuration loaded successfully")
-        return config
-    except json.JSONDecodeError as e:
-        logger.error(f"❌ Error: Invalid JSON in configuration file: {e}")
-        raise
+    return _auth.load_config(config_path, Path(__file__).parent)
 
 
 def main(config: Dict[str, Any]) -> None:

--- a/google/weekly_photo_automation.py
+++ b/google/weekly_photo_automation.py
@@ -6,7 +6,6 @@ Creates weekly Google Photos albums for children and shares them via email.
 
 # Standard library imports
 import argparse
-import json
 import logging
 import os
 import sys
@@ -15,12 +14,11 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 
 # Third-party library imports
-from google.auth.transport.requests import Request
-from google.oauth2.credentials import Credentials
-from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 import pytz
+
+import _auth
 
 # Configure logging
 logging.basicConfig(
@@ -49,39 +47,19 @@ class WeeklyPhotoAutomation:
     def load_config(self, config_path: str) -> Dict[str, Any]:
         """
         Load configuration from JSON file.
-        
+
         Args:
             config_path: Path to configuration file
-            
+
         Returns:
             Configuration dictionary
         """
-        logger.debug("📂 Loading configuration file")
-        
-        # Get the script directory and resolve config path relative to it
-        script_dir = Path(__file__).parent
-        if Path(config_path).is_absolute():
-            config_full_path = Path(config_path)
-        else:
-            config_full_path = script_dir / config_path
-            
-        if not config_full_path.exists():
-            logger.error(f"❌ Error: Configuration file not found at {config_full_path}")
-            raise FileNotFoundError(f"Configuration file not found: {config_full_path}")
-        
-        try:
-            with open(config_full_path, 'r', encoding='utf-8') as e:
-                config = json.load(e)
-            logger.info("✅ Configuration loaded successfully")
-            return config
-        except json.JSONDecodeError as e:
-            logger.error(f"❌ Error: Invalid JSON in configuration file: {e}")
-            raise
-            
+        return _auth.load_config(config_path, Path(__file__).parent)
+
     def authenticate_google_services(self) -> None:
         """Authenticate with Google Photos and Gmail APIs."""
         logger.info("🔐 Authenticating with Google services")
-        
+
         SCOPES = [
             # Photos Library API - Core scopes
             'https://www.googleapis.com/auth/photoslibrary',
@@ -90,7 +68,7 @@ class WeeklyPhotoAutomation:
             'https://www.googleapis.com/auth/photoslibrary.sharing',
             'https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata',
             'https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata',
-            
+
             # Gmail API - All scopes you've added
             'https://www.googleapis.com/auth/gmail.send',
             'https://www.googleapis.com/auth/gmail.compose',
@@ -107,59 +85,10 @@ class WeeklyPhotoAutomation:
             'https://www.googleapis.com/auth/gmail.addons.current.message.readonly',
             'https://mail.google.com/'  # Full Gmail access
         ]
-        
-        creds = None
-        
-        # Get the script directory and resolve paths relative to it
-        script_dir = Path(__file__).parent
-        
-        # Handle token file path
-        token_path = Path(self.config['auth']['token_file'])
-        if not token_path.is_absolute():
-            token_path = script_dir / token_path
-            
-        # Handle credentials file path
-        credentials_path = Path(self.config['auth']['credentials_file'])
-        if not credentials_path.is_absolute():
-            credentials_path = script_dir / credentials_path
-        
-        # Load existing token
-        if token_path.exists():
-            creds = Credentials.from_authorized_user_file(str(token_path), SCOPES)
-            # Refresh credentials to ensure they're valid
-            try:
-                creds.refresh(Request())
-                logger.info("🔄 Credentials refreshed successfully")
-            except Exception as e:
-                logger.warning(f"⚠️ Failed to refresh credentials: {e}")
-                creds = None
-            
-        # If there are no (valid) credentials, let the user log in
-        if not creds or not creds.valid:
-            if creds and creds.expired and creds.refresh_token:
-                logger.info("🔄 Refreshing expired credentials")
-                creds.refresh(Request())
-            else:
-                logger.info("🔑 Requesting new authentication")
-                flow = InstalledAppFlow.from_client_secrets_file(
-                    str(credentials_path), SCOPES
-                )
-                creds = flow.run_local_server(
-                    port=0,
-                    access_type="offline",  # get a refresh token
-                    prompt="consent",  # force the consent screen, don't reuse old grant
-                    include_granted_scopes=False  # don't merge with an older, narrower grant
-                )
-                # force a fresh access token right now
-                creds.refresh(Request())
-                logger.info(f"Granted scopes from token: {creds.scopes}")
-                
-            # Save credentials for next run
-            with open(token_path, 'w') as token:
-                token.write(creds.to_json())
-                
+
+        creds = _auth.authenticate(self.config, Path(__file__).parent, SCOPES)
         self.credentials = creds
-        
+
         # Build Google Photos Library API service
         try:
             # First try with static discovery disabled

--- a/image/_image_to_jpg_converter.py
+++ b/image/_image_to_jpg_converter.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+"""
+Shared folder-batch image -> JPG conversion scaffolding.
+
+Consolidates the "folder-pick -> collect files by extension -> per-file
+validate -> PIL load -> RGB convert -> save JPG -> count/skip -> completion
+messagebox" shape duplicated between heic_to_jpg_converter.py and
+png_to_jpg_converter.py (dedup: audit issue #64).
+
+The two callers differ meaningfully in how they make an image JPEG-safe
+(HEIC: naive RGB convert; PNG: alpha-composite onto a white background),
+whether they protect an existing same-named .jpg from being overwritten
+(HEIC: yes; PNG: no - preserved as-is, not fixed here), and their JPEG
+save quality kwargs - so only the genuinely identical scaffolding lives
+here; those differences stay as caller-supplied parameters.
+"""
+
+import logging
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from pathlib import Path
+from typing import Callable, Dict, Iterable
+
+from PIL import Image, UnidentifiedImageError
+
+
+def select_folder(dialog_title: str) -> str:
+    """Open a folder-selection dialog and return the chosen path (or '' if cancelled)."""
+    root = tk.Tk()
+    root.withdraw()  # Hide the main window
+    folder_path = filedialog.askdirectory(title=dialog_title)
+    root.destroy()
+    return folder_path
+
+
+def show_completion_messagebox(title: str, message: str) -> None:
+    """Show a simple info messagebox (used for the "conversion complete" popup)."""
+    root = tk.Tk()
+    root.withdraw()
+    messagebox.showinfo(title, message)
+    root.destroy()
+
+
+def convert_folder_to_jpg(
+    folder_path: str,
+    source_extensions: Iterable[str],
+    validate_fn: Callable[[Path], bool],
+    convert_to_rgb_fn: Callable[["Image.Image"], "Image.Image"],
+    save_kwargs: Dict,
+    *,
+    skip_existing_jpg: bool,
+    logger: logging.Logger,
+    kind_label: str = "image",
+) -> None:
+    """
+    Convert every file under `folder_path` matching `source_extensions` to JPG.
+
+    Args:
+        source_extensions: file extensions to scan for (e.g. ['.heic', '.heif']).
+        validate_fn:       fn(path) -> bool, run before conversion (integrity check).
+        convert_to_rgb_fn: fn(img) -> img, applied after img.load() to make the
+                            image JPEG-savable (handles transparency/mode per caller).
+        save_kwargs:       passed straight to Image.save(path, 'JPEG', **save_kwargs).
+        skip_existing_jpg: if True, an existing same-named .jpg is left untouched
+                            (counted as an error/skip); if False, it's overwritten.
+        kind_label:        short label used in log messages (e.g. "HEIC/HEIF", "PNG").
+    """
+    if not folder_path:
+        logger.info("No folder selected.")
+        return
+
+    folder = Path(folder_path)
+    if not folder.exists():
+        logger.error("❌ Folder does not exist: %s", folder_path)
+        return
+
+    exts = {e.lower() for e in source_extensions}
+    files = [f for f in folder.iterdir() if f.is_file() and f.suffix.lower() in exts]
+
+    if not files:
+        logger.info("❌ No %s files found in the selected folder.", kind_label)
+        return
+
+    converted_count = 0
+    error_count = 0
+
+    logger.info("📂 Found %d %s files in %s", len(files), kind_label, folder_path)
+    logger.info("🔄 Starting conversion...")
+
+    for src_file in files:
+        if not validate_fn(src_file):
+            logger.warning("⚠️  Skipping %s - invalid or corrupted %s file", src_file.name, kind_label)
+            error_count += 1
+            continue
+
+        jpg_file = src_file.with_suffix('.jpg')
+
+        if skip_existing_jpg and jpg_file.exists():
+            logger.warning("⚠️  JPG already exists for %s, skipping", src_file.name)
+            error_count += 1
+            continue
+
+        try:
+            with Image.open(src_file) as img:
+                img.load()
+                img = convert_to_rgb_fn(img)
+                img.save(jpg_file, 'JPEG', **save_kwargs)
+                logger.info("✅ Converted %s -> %s", src_file.name, jpg_file.name)
+                converted_count += 1
+        except UnidentifiedImageError as e:
+            logger.error("❌ Cannot identify image file '%s': %s", src_file, e)
+            error_count += 1
+        except OSError as e:
+            logger.error("❌ OS error processing '%s': %s", src_file, e)
+            error_count += 1
+        except Exception as e:
+            logger.error("❌ Error converting %s: %s", src_file.name, e)
+            error_count += 1
+
+    logger.info("🎉 Conversion complete!")
+    logger.info("✅ Converted: %d files", converted_count)
+    logger.info("❌ Errors: %d files", error_count)
+
+    if error_count > 0:
+        logger.info("📝 Note: %d files had errors and were skipped.", error_count)
+        logger.info("This could be due to corrupted files, unsupported formats, or permission issues.")

--- a/image/heic_to_jpg_converter.py
+++ b/image/heic_to_jpg_converter.py
@@ -22,12 +22,11 @@ Usage:
     python heic_to_jpg_converter.py
 """
 
-import tkinter as tk
-from tkinter import filedialog, messagebox
 from PIL import Image, UnidentifiedImageError
-import os
 from pathlib import Path
 import logging
+
+from _image_to_jpg_converter import select_folder, convert_folder_to_jpg, show_completion_messagebox
 
 logger = logging.getLogger(__name__)
 
@@ -43,18 +42,6 @@ except ImportError as e:
     # pillow-heif not installed - HEIC files cannot be opened
     logger.warning("⚠️  pillow-heif not available: %s. HEIC conversion may not work.", e)
     pillow_heif_available = False
-
-def select_folder() -> str:
-    """Open folder dialog and return selected folder path"""
-    root = tk.Tk()
-    root.withdraw()  # Hide the main window
-
-    folder_path = filedialog.askdirectory(
-        title="Select folder containing HEIC images"
-    )
-
-    root.destroy()
-    return folder_path
 
 def validate_heic_file(file_path: Path) -> bool:
     """
@@ -87,98 +74,32 @@ def validate_heic_file(file_path: Path) -> bool:
         logger.error("❌ Unexpected error with HEIC file '%s': %s", file_path, e)
         return False
 
+def _heic_to_rgb(img: "Image.Image") -> "Image.Image":
+    """
+    Convert image mode to RGB for JPG compatibility.
+    HEIC files can be in various modes (RGBA, CMYK, etc.); JPG format
+    requires RGB or grayscale (L) mode.
+    """
+    if img.mode not in ('RGB', 'L'):
+        img = img.convert('RGB')
+    return img
+
+
 def convert_heic_to_jpg(folder_path: str) -> None:
     """Convert all HEIC/HEIF images in the folder to JPG format"""
-    if not folder_path:
-        logger.info("No folder selected.")
-        return
-
-    folder = Path(folder_path)
-    if not folder.exists():
-        logger.error("❌ Folder does not exist: %s", folder_path)
-        return
-
-    # Find all HEIC/HEIF files in the folder (case insensitive)
-    # HEIC (High Efficiency Image Container) and HEIF (High Efficiency Image Format)
-    # are Apple's efficient image formats used by iPhones and other devices
-    heic_files = []
-    heic_extensions = ['.heic', '.heif']  # Both extensions are supported
-
-    for file in folder.iterdir():
-        # Check file extension case-insensitively to catch .HEIC, .Heic, etc.
-        if file.is_file() and file.suffix.lower() in heic_extensions:
-            heic_files.append(file)
-
-    if not heic_files:
-        logger.info("❌ No HEIC/HEIF files found in the selected folder.")
-        return
-
-    converted_count = 0
-    error_count = 0
-
-    logger.info("📂 Found %d HEIC/HEIF files in %s", len(heic_files), folder_path)
-    logger.info("🔄 Starting conversion...")
-
-    for heic_file in heic_files:
-        # Validate the HEIC file first
-        if not validate_heic_file(heic_file):
-            logger.warning("⚠️  Skipping %s - invalid or corrupted HEIC file", heic_file.name)
-            error_count += 1
-            continue
-
-        # Create JPG filename with same name but .jpg extension
-        jpg_file = heic_file.with_suffix('.jpg')
-
-        # Check if JPG already exists
-        if jpg_file.exists():
-            logger.warning("⚠️  JPG already exists for %s, skipping", heic_file.name)
-            error_count += 1
-            continue
-
-        try:
-            # Open HEIC image using PIL with pillow-heif extension
-            with Image.open(heic_file) as img:
-                # img.load() forces loading of image data into memory
-                # This is necessary for HEIC files which may use lazy loading
-                img.load()
-
-                # Convert image mode to RGB for JPG compatibility
-                # HEIC files can be in various modes (RGBA, CMYK, etc.)
-                # JPG format requires RGB or grayscale (L) mode
-                if img.mode not in ('RGB', 'L'):
-                    # Convert to RGB to ensure compatibility with JPG format
-                    # This handles transparency (RGBA) and other color modes
-                    img = img.convert('RGB')
-
-                # Save as JPG with optimized settings for quality preservation
-                # quality=95: High quality (95%) - excellent visual quality with reasonable file size
-                # optimize=True: Enable optimization to reduce file size without quality loss
-                # progressive=True: Progressive JPG for better web loading (loads blurry to sharp)
-                img.save(jpg_file, 'JPEG', quality=95, optimize=True, progressive=True)
-
-                logger.info("✅ Converted %s -> %s", heic_file.name, jpg_file.name)
-                converted_count += 1
-
-        except UnidentifiedImageError as e:
-            if not pillow_heif_available:
-                logger.error("❌ Cannot convert '%s': pillow-heif not available. Install with: pip install pillow-heif", heic_file.name)
-            else:
-                logger.error("❌ Cannot identify image file '%s': %s", heic_file, e)
-            error_count += 1
-        except OSError as e:
-            logger.error("❌ OS error processing '%s': %s", heic_file, e)
-            error_count += 1
-        except Exception as e:
-            logger.error("❌ Error converting %s: %s", heic_file.name, e)
-            error_count += 1
-
-    logger.info("🎉 Conversion complete!")
-    logger.info("✅ Converted: %d files", converted_count)
-    logger.info("❌ Errors: %d files", error_count)
-
-    if error_count > 0:
-        logger.info("📝 Note: %d files had errors and were skipped.", error_count)
-        logger.info("This could be due to corrupted files, unsupported formats, or permission issues.")
+    convert_folder_to_jpg(
+        folder_path,
+        source_extensions=['.heic', '.heif'],  # HEIC and HEIF: Apple's efficient image formats
+        validate_fn=validate_heic_file,
+        convert_to_rgb_fn=_heic_to_rgb,
+        # quality=95: excellent visual quality with reasonable file size
+        # optimize=True: reduce file size without quality loss
+        # progressive=True: progressive JPG for better web loading (loads blurry to sharp)
+        save_kwargs={'quality': 95, 'optimize': True, 'progressive': True},
+        skip_existing_jpg=True,
+        logger=logger,
+        kind_label='HEIC/HEIF',
+    )
 
 def main() -> None:
     """Main function to run the HEIC to JPG converter"""
@@ -196,20 +117,17 @@ def main() -> None:
         logger.warning("   Note: Continue anyway to see specific error messages per file")
 
     # Select folder
-    folder_path = select_folder()
+    folder_path = select_folder("Select folder containing HEIC images")
 
     if folder_path:
         # Convert HEIC files to JPG
         convert_heic_to_jpg(folder_path)
 
         # Show completion message
-        root = tk.Tk()
-        root.withdraw()
-        messagebox.showinfo(
+        show_completion_messagebox(
             "Conversion Complete",
-            f"HEIC to JPG conversion completed!\n\nCheck the selected folder for converted files."
+            "HEIC to JPG conversion completed!\n\nCheck the selected folder for converted files."
         )
-        root.destroy()
     else:
         logger.info("❌ No folder selected. Exiting.")
 

--- a/image/illustrations_formatter.py
+++ b/image/illustrations_formatter.py
@@ -45,6 +45,25 @@ class ProcessingResult:
     errors: List[Tuple[str, str]]
 
 
+def default_illustrations_config() -> Dict[str, Any]:
+    """Built-in defaults for illustrations_formatter_config.json.
+
+    Shared by IllustrationsFormatter.load_config() and
+    IllustrationsFormatterGUI.load_config() (dedup: audit issue #64) - returns
+    a fresh dict each call so callers can safely mutate their copy.
+    """
+    return {
+        'source_folder': '',
+        'destination_folder': '',
+        'destination_folder_instagram': os.getenv('ILLUSTRATIONS_DEST_INSTAGRAM', ''),
+        'destination_folder_1920x1080': os.getenv('ILLUSTRATIONS_DEST_1920X1080', ''),
+        'aspect_ratio': '3:4',
+        'background_color': '',
+        'format_type': 'instagram',
+        'extend_border': False,
+    }
+
+
 class IllustrationsFormatter:
     """Main class for formatting images."""
 
@@ -82,16 +101,7 @@ class IllustrationsFormatter:
     def load_config(self) -> Dict[str, Any]:
         """Load configuration from the JSON file, merging with built-in defaults."""
         config_path = Path(__file__).parent / self.CONFIG_FILE
-        default_config = {
-            'source_folder': '',
-            'destination_folder': '',
-            'destination_folder_instagram': os.getenv('ILLUSTRATIONS_DEST_INSTAGRAM', ''),
-            'destination_folder_1920x1080': os.getenv('ILLUSTRATIONS_DEST_1920X1080', ''),
-            'aspect_ratio': '3:4',
-            'background_color': '',
-            'format_type': 'instagram',
-            'extend_border': False,
-        }
+        default_config = default_illustrations_config()
         try:
             if config_path.exists():
                 with open(config_path, 'r', encoding='utf-8') as f:
@@ -434,6 +444,90 @@ class IllustrationsFormatter:
     # Batch-folder methods
     # ------------------------------------------------------------------
 
+    def _process_folder_common(
+        self,
+        source_folder: str,
+        destination_folder: str,
+        skip_predicate,
+        per_image_fn,
+        progress_callback=None,
+    ) -> ProcessingResult:
+        """
+        Shared batch-folder scaffolding for process_folder / process_folder_fixed_size:
+        source validation, glob-collection (with case-duplicate handling), the
+        already-processed skip check, error accumulation, and the final
+        ProcessingResult build.
+
+        Args:
+            skip_predicate: ``fn(existing_image: Image) -> bool`` - decides
+                whether an already-existing destination file matches the
+                target shape and can be skipped.
+            per_image_fn:   ``fn(img_path: Path, out: Path) -> None`` - does
+                the actual per-image conversion; may raise on failure.
+        """
+        start_time = time.time()
+        errors: List[Tuple[str, str]] = []
+
+        source_path = Path(source_folder)
+        dest_path = Path(destination_folder)
+
+        if not source_path.exists():
+            raise ValueError(f"Source folder does not exist: {source_folder}")
+        if not source_path.is_dir():
+            raise ValueError(f"Source path is not a directory: {source_folder}")
+
+        dest_path.mkdir(parents=True, exist_ok=True)
+
+        image_files: List[Path] = []
+        for ext in self.SUPPORTED_FORMATS:
+            image_files.extend(source_path.glob(f'*{ext}'))
+            image_files.extend(source_path.glob(f'*{ext.upper()}'))
+        image_files = list(set(image_files))
+        total = len(image_files)
+
+        if total == 0:
+            self.logger.warning(f"No supported image files found in: {source_folder}")
+            return ProcessingResult(0, 0, 0, 0, 0.0, [])
+
+        self.logger.info(f"Found {total} image(s) to process")
+        successful = failed = skipped = 0
+
+        for idx, img_path in enumerate(image_files, 1):
+            try:
+                out = dest_path / img_path.name
+                if out.exists():
+                    try:
+                        with Image.open(out) as ex:
+                            if skip_predicate(ex):
+                                self.logger.info(f"Skipping already processed: {out.name}")
+                                skipped += 1
+                                if progress_callback:
+                                    progress_callback(idx, total, f"Skipping: {img_path.name}")
+                                continue
+                    except Exception as e:
+                        self.logger.warning(
+                            f"Could not verify {out.name}, re-processing. Error: {e}"
+                        )
+                per_image_fn(img_path, out)
+                successful += 1
+                if progress_callback:
+                    progress_callback(idx, total, f"Processing: {img_path.name}")
+            except Exception as e:
+                failed += 1
+                self.logger.error(f"Failed to process {img_path.name}: {e}")
+                errors.append((img_path.name, str(e)))
+                if progress_callback:
+                    progress_callback(idx, total, f"Error: {img_path.name}")
+
+        elapsed = time.time() - start_time
+        self.logger.info(
+            f"\nProcessing complete! "
+            f"Total: {total}  Successful: {successful}  "
+            f"Skipped: {skipped}  Failed: {failed}  "
+            f"Time: {elapsed:.2f}s"
+        )
+        return ProcessingResult(total, successful, failed, skipped, elapsed, errors)
+
     def process_folder(
         self,
         source_folder: str,
@@ -461,75 +555,20 @@ class IllustrationsFormatter:
         Returns:
             :class:`ProcessingResult` with counts and any error details.
         """
-        start_time = time.time()
-        errors: List[Tuple[str, str]] = []
-
-        source_path = Path(source_folder)
-        dest_path = Path(destination_folder)
-
-        if not source_path.exists():
-            raise ValueError(f"Source folder does not exist: {source_folder}")
-        if not source_path.is_dir():
-            raise ValueError(f"Source path is not a directory: {source_folder}")
-
         try:
             ratio_float = self.parse_aspect_ratio(aspect_ratio)
         except ValueError as e:
             raise ValueError(f"Invalid aspect ratio: {e}")
 
-        dest_path.mkdir(parents=True, exist_ok=True)
-
-        image_files: List[Path] = []
-        for ext in self.SUPPORTED_FORMATS:
-            image_files.extend(source_path.glob(f'*{ext}'))
-            image_files.extend(source_path.glob(f'*{ext.upper()}'))
-        image_files = list(set(image_files))
-        total = len(image_files)
-
-        if total == 0:
-            self.logger.warning(f"No supported image files found in: {source_folder}")
-            return ProcessingResult(0, 0, 0, 0, 0.0, [])
-
-        self.logger.info(f"Found {total} image(s) to process")
-        successful = failed = skipped = 0
-
-        for idx, img_path in enumerate(image_files, 1):
-            try:
-                out = dest_path / img_path.name
-                if out.exists():
-                    try:
-                        with Image.open(out) as ex:
-                            if abs(ex.width / ex.height - ratio_float) < 0.01:
-                                self.logger.info(f"Skipping already processed: {out.name}")
-                                skipped += 1
-                                if progress_callback:
-                                    progress_callback(idx, total, f"Skipping: {img_path.name}")
-                                continue
-                    except Exception as e:
-                        self.logger.warning(
-                            f"Could not verify {out.name}, re-processing. Error: {e}"
-                        )
-                self.process_image(
-                    img_path, out, ratio_float, background_color, extend_border
-                )
-                successful += 1
-                if progress_callback:
-                    progress_callback(idx, total, f"Processing: {img_path.name}")
-            except Exception as e:
-                failed += 1
-                self.logger.error(f"Failed to process {img_path.name}: {e}")
-                errors.append((img_path.name, str(e)))
-                if progress_callback:
-                    progress_callback(idx, total, f"Error: {img_path.name}")
-
-        elapsed = time.time() - start_time
-        self.logger.info(
-            f"\nProcessing complete! "
-            f"Total: {total}  Successful: {successful}  "
-            f"Skipped: {skipped}  Failed: {failed}  "
-            f"Time: {elapsed:.2f}s"
+        return self._process_folder_common(
+            source_folder,
+            destination_folder,
+            skip_predicate=lambda ex: abs(ex.width / ex.height - ratio_float) < 0.01,
+            per_image_fn=lambda img_path, out: self.process_image(
+                img_path, out, ratio_float, background_color, extend_border
+            ),
+            progress_callback=progress_callback,
         )
-        return ProcessingResult(total, successful, failed, skipped, elapsed, errors)
 
     def process_folder_fixed_size(
         self,
@@ -560,72 +599,15 @@ class IllustrationsFormatter:
         Returns:
             :class:`ProcessingResult` with counts and any error details.
         """
-        start_time = time.time()
-        errors: List[Tuple[str, str]] = []
-
-        source_path = Path(source_folder)
-        dest_path = Path(destination_folder)
-
-        if not source_path.exists():
-            raise ValueError(f"Source folder does not exist: {source_folder}")
-        if not source_path.is_dir():
-            raise ValueError(f"Source path is not a directory: {source_folder}")
-
-        dest_path.mkdir(parents=True, exist_ok=True)
-
-        image_files: List[Path] = []
-        for ext in self.SUPPORTED_FORMATS:
-            image_files.extend(source_path.glob(f'*{ext}'))
-            image_files.extend(source_path.glob(f'*{ext.upper()}'))
-        image_files = list(set(image_files))
-        total = len(image_files)
-
-        if total == 0:
-            self.logger.warning(f"No supported image files found in: {source_folder}")
-            return ProcessingResult(0, 0, 0, 0, 0.0, [])
-
-        self.logger.info(f"Found {total} image(s) to process")
-        successful = failed = skipped = 0
-
-        for idx, img_path in enumerate(image_files, 1):
-            try:
-                out = dest_path / img_path.name
-                if out.exists():
-                    try:
-                        with Image.open(out) as ex:
-                            if ex.width == target_width and ex.height == target_height:
-                                self.logger.info(f"Skipping already processed: {out.name}")
-                                skipped += 1
-                                if progress_callback:
-                                    progress_callback(idx, total, f"Skipping: {img_path.name}")
-                                continue
-                    except Exception as e:
-                        self.logger.warning(
-                            f"Could not verify {out.name}, re-processing. Error: {e}"
-                        )
-                self.process_image_fixed_size(
-                    img_path, out,
-                    target_width, target_height,
-                    background_color, extend_border,
-                )
-                successful += 1
-                if progress_callback:
-                    progress_callback(idx, total, f"Processing: {img_path.name}")
-            except Exception as e:
-                failed += 1
-                self.logger.error(f"Failed to process {img_path.name}: {e}")
-                errors.append((img_path.name, str(e)))
-                if progress_callback:
-                    progress_callback(idx, total, f"Error: {img_path.name}")
-
-        elapsed = time.time() - start_time
-        self.logger.info(
-            f"\nProcessing complete! "
-            f"Total: {total}  Successful: {successful}  "
-            f"Skipped: {skipped}  Failed: {failed}  "
-            f"Time: {elapsed:.2f}s"
+        return self._process_folder_common(
+            source_folder,
+            destination_folder,
+            skip_predicate=lambda ex: ex.width == target_width and ex.height == target_height,
+            per_image_fn=lambda img_path, out: self.process_image_fixed_size(
+                img_path, out, target_width, target_height, background_color, extend_border
+            ),
+            progress_callback=progress_callback,
         )
-        return ProcessingResult(total, successful, failed, skipped, elapsed, errors)
 
 
 # ----------------------------------------------------------------------

--- a/image/illustrations_formatter_gui.py
+++ b/image/illustrations_formatter_gui.py
@@ -32,10 +32,20 @@ import sys
 import os
 
 try:
-    from illustrations_formatter import IllustrationsFormatter, ProcessingResult, parse_color
+    from illustrations_formatter import (
+        IllustrationsFormatter,
+        ProcessingResult,
+        parse_color,
+        default_illustrations_config,
+    )
 except ImportError:
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-    from illustrations_formatter import IllustrationsFormatter, ProcessingResult, parse_color
+    from illustrations_formatter import (
+        IllustrationsFormatter,
+        ProcessingResult,
+        parse_color,
+        default_illustrations_config,
+    )
 
 
 class TextHandler(logging.Handler):
@@ -67,7 +77,8 @@ class IllustrationsFormatterGUI:
       a status line, and a scrollable log.
     """
 
-    CONFIG_FILE = 'illustrations_formatter_config.json'
+    # Shared with the core module (dedup: audit issue #64) - see illustrations_formatter.py.
+    CONFIG_FILE = IllustrationsFormatter.CONFIG_FILE
     DEFAULT_1920X1080_FOLDER = os.getenv('ILLUSTRATIONS_DEST_1920X1080', '')
     DEFAULT_INSTAGRAM_FOLDER = os.getenv('ILLUSTRATIONS_DEST_INSTAGRAM', '')
 
@@ -113,16 +124,7 @@ class IllustrationsFormatterGUI:
     def load_config(self) -> Dict[str, Any]:
         """Load settings from the JSON config file, merging with built-in defaults."""
         config_path = Path(__file__).parent / self.CONFIG_FILE
-        defaults: Dict[str, Any] = {
-            'source_folder': '',
-            'destination_folder': '',
-            'destination_folder_instagram': self.DEFAULT_INSTAGRAM_FOLDER,
-            'destination_folder_1920x1080': self.DEFAULT_1920X1080_FOLDER,
-            'aspect_ratio': '3:4',
-            'background_color': '',
-            'format_type': 'instagram',
-            'extend_border': False,
-        }
+        defaults: Dict[str, Any] = default_illustrations_config()
         try:
             if config_path.exists():
                 with open(config_path, 'r', encoding='utf-8') as f:

--- a/image/image_resizer.py
+++ b/image/image_resizer.py
@@ -24,92 +24,51 @@ SUPPORTED_FORMATS = {'.jpg', '.jpeg', '.png', '.gif', '.bmp', '.tiff', '.webp'}
 if HEIC_SUPPORT:
     SUPPORTED_FORMATS.update({'.heic', '.heif'})
 
-def resize_image_quality_only(image_path: Path, max_size_kb: float, quality_start: int = 95) -> bool:
-    """
-    Resize image by reducing only quality (not dimensions) to meet maximum file size requirement.
-    Returns True if successful, False otherwise.
-    """
-    try:
-        # Create a temporary file for the resized image
-        temp_path = image_path.parent / f"{image_path.stem}_temp{image_path.suffix}"
-        
-        # Open image
-        img = Image.open(image_path)
-        
-        # Convert RGBA to RGB if necessary for JPEG
-        if img.mode == 'RGBA' and image_path.suffix.lower() in ['.jpg', '.jpeg']:
-            rgb_img = Image.new('RGB', img.size, (255, 255, 255))
-            rgb_img.paste(img, mask=img.split()[3])
-            img = rgb_img
-        
-        # Convert HEIC to RGB for better compatibility when saving
-        if image_path.suffix.lower() in ['.heic', '.heif'] and img.mode != 'RGB':
-            img = img.convert('RGB')
-        
-        # Save the image with decreasing quality until the file size is under the limit
-        for quality in range(quality_start, 0, -5):
-            # Save with current quality without resizing
-            if image_path.suffix.lower() in ['.jpg', '.jpeg']:
-                img.save(temp_path, optimize=True, quality=quality)
-            elif image_path.suffix.lower() in ['.heic', '.heif']:
-                # Save HEIC as JPEG with quality control
-                temp_path = temp_path.with_suffix('.jpg')
-                img.save(temp_path, 'JPEG', optimize=True, quality=quality)
-            else:
-                img.save(temp_path, optimize=True)
-            
-            # Check the file size
-            new_size_kb = os.path.getsize(temp_path) / 1024
-            if new_size_kb <= max_size_kb:
-                # Size is good, save with proper name
-                if image_path.suffix.lower() in ['.heic', '.heif']:
-                    # Save HEIC as JPEG
-                    output_path = image_path.parent / f"{image_path.stem}_resize.jpg"
-                else:
-                    output_path = image_path.parent / f"{image_path.stem}_resize{image_path.suffix}"
-                temp_path.rename(output_path)
-                logger.info(f"Success: Resized to {new_size_kb:.2f} KB (quality: {quality}, dimensions unchanged)")
-                return True
-        
-        # If we reach here, we couldn't reduce the size enough with quality alone
-        logger.warning(f"Failed to resize {image_path} to under {max_size_kb} KB with quality reduction only")
-        return False
-    except Exception as e:
-        logger.error(f"Error processing {image_path}: {str(e)}")
-        return False
-
-def resize_image_to_max_size(image_path: Path, max_size_kb: float, quality_start: int = 95) -> bool:
+def resize_image_to_max_size(
+    image_path: Path,
+    max_size_kb: float,
+    quality_start: int = 95,
+    preserve_dimensions: bool = False,
+) -> bool:
     """
     Resize image to meet maximum file size requirement.
+
+    If preserve_dimensions is True, only quality is reduced (dimensions stay
+    fixed). Otherwise, dimensions are progressively shrunk (10% per step, via
+    LANCZOS-resampled thumbnail()) in addition to lowering quality.
+
     Returns True if successful, False otherwise.
     """
     try:
         # Create a temporary file for the resized image
         temp_path = image_path.parent / f"{image_path.stem}_temp{image_path.suffix}"
-        
+
         # Open image
         img = Image.open(image_path)
-        
+
         # Convert RGBA to RGB if necessary for JPEG
         if img.mode == 'RGBA' and image_path.suffix.lower() in ['.jpg', '.jpeg']:
             rgb_img = Image.new('RGB', img.size, (255, 255, 255))
             rgb_img.paste(img, mask=img.split()[3])
             img = rgb_img
-        
+
         # Convert HEIC to RGB for better compatibility when saving
         if image_path.suffix.lower() in ['.heic', '.heif'] and img.mode != 'RGB':
             img = img.convert('RGB')
-        
-        # Save the image with decreasing dimensions and quality until the file size is under the limit
+
         orig_width, orig_height = img.width, img.height
+
+        # Save the image with decreasing quality (and, unless preserve_dimensions,
+        # decreasing dimensions too) until the file size is under the limit
         for i, quality in enumerate(range(quality_start, 0, -5)):
-            # Shrink dimensions progressively each iteration (10% smaller per step),
-            # in addition to lowering quality - using LANCZOS resampling.
-            # img is re-opened at full size at the end of each iteration, so the
-            # target is computed against the original dimensions with a per-iteration factor.
-            factor = 0.9 ** i
-            target = (max(1, int(orig_width * factor)), max(1, int(orig_height * factor)))
-            img.thumbnail(target, Image.Resampling.LANCZOS)
+            if not preserve_dimensions:
+                # Shrink dimensions progressively each iteration (10% smaller per step),
+                # in addition to lowering quality - using LANCZOS resampling.
+                # img is re-opened at full size at the end of each iteration, so the
+                # target is computed against the original dimensions with a per-iteration factor.
+                factor = 0.9 ** i
+                target = (max(1, int(orig_width * factor)), max(1, int(orig_height * factor)))
+                img.thumbnail(target, Image.Resampling.LANCZOS)
 
             # Save with current quality
             if image_path.suffix.lower() in ['.jpg', '.jpeg']:
@@ -120,7 +79,7 @@ def resize_image_to_max_size(image_path: Path, max_size_kb: float, quality_start
                 img.save(temp_path, 'JPEG', optimize=True, quality=quality)
             else:
                 img.save(temp_path, optimize=True)
-            
+
             # Check the file size
             new_size_kb = os.path.getsize(temp_path) / 1024
             if new_size_kb <= max_size_kb:
@@ -131,17 +90,33 @@ def resize_image_to_max_size(image_path: Path, max_size_kb: float, quality_start
                 else:
                     output_path = image_path.parent / f"{image_path.stem}_resize{image_path.suffix}"
                 temp_path.rename(output_path)
-                logger.info(f"Success: Resized to {new_size_kb:.2f} KB (quality: {quality})")
+                if preserve_dimensions:
+                    logger.info(f"Success: Resized to {new_size_kb:.2f} KB (quality: {quality}, dimensions unchanged)")
+                else:
+                    logger.info(f"Success: Resized to {new_size_kb:.2f} KB (quality: {quality})")
                 return True
-            
-            # Reset image for the next iteration
-            img = Image.open(image_path)
-        
-        logger.warning(f"Failed to resize {image_path} to under {max_size_kb} KB")
+
+            if not preserve_dimensions:
+                # Reset image for the next iteration
+                img = Image.open(image_path)
+
+        # If we reach here, we couldn't reduce the size enough
+        if preserve_dimensions:
+            logger.warning(f"Failed to resize {image_path} to under {max_size_kb} KB with quality reduction only")
+        else:
+            logger.warning(f"Failed to resize {image_path} to under {max_size_kb} KB")
         return False
     except Exception as e:
         logger.error(f"Error processing {image_path}: {str(e)}")
         return False
+
+
+def resize_image_quality_only(image_path: Path, max_size_kb: float, quality_start: int = 95) -> bool:
+    """
+    Resize image by reducing only quality (not dimensions) to meet maximum file size requirement.
+    Returns True if successful, False otherwise.
+    """
+    return resize_image_to_max_size(image_path, max_size_kb, quality_start, preserve_dimensions=True)
 
 def process_folder(folder_path: Path, max_size_kb: float, preserve_dimensions: bool = False):
     """
@@ -151,7 +126,7 @@ def process_folder(folder_path: Path, max_size_kb: float, preserve_dimensions: b
         if file_path.suffix.lower() in SUPPORTED_FORMATS:
             logger.info(f"Processing {file_path}")
             if preserve_dimensions:
-                success = resize_image_quality_only(file_path, max_size_kb)
+                success = resize_image_to_max_size(file_path, max_size_kb, preserve_dimensions=True)
                 # Fall back to normal resize if quality-only didn't work
                 if not success:
                     logger.info(f"Trying standard resize with dimension reduction for {file_path}")

--- a/image/photos_archive.py
+++ b/image/photos_archive.py
@@ -572,6 +572,88 @@ def delete_copied_files(df: pd.DataFrame) -> None:
 
     logging.info("%d files deleted", deleted_files_count)
 
+def _apply_exclusion_thresholds(df: pd.DataFrame) -> None:
+    """
+    Display the top unified days and prompt for the exclude-days-over-X,
+    short-sequence, and creation/modified-criteria exclusion thresholds,
+    mutating df['exclude'] in place.
+
+    Shared by main()'s "use existing metadata + recalculate" and "fresh scan"
+    flows (dedup: audit issue #64).
+    """
+    top_days = df['unified_day'].value_counts().head(20)
+    for idx, (day, count) in enumerate(top_days.items(), start=1):
+        logging.info("#{:02d} - {} - {} files".format(idx, day, count))
+
+    # Ask for exclusion threshold
+    default_exclude_threshold = CONFIG['processing_thresholds']['exclude_days_over_files']
+    exclude_threshold_input = input(f"Do you want to exclude days with more than X files? Enter X value, or zero if you don't want to exclude any file (default: {default_exclude_threshold}): ").strip()
+    exclude_threshold = int(exclude_threshold_input) if exclude_threshold_input else default_exclude_threshold
+    if exclude_threshold > 0:
+        df.loc[df['total_files_unified_day'] > exclude_threshold, 'exclude'] = 1
+
+    # Ask for short sequence exclusion threshold
+    default_short_seq_threshold = CONFIG['processing_thresholds']['exclude_short_sequences_over']
+    short_seq_threshold_input = input(f"Enter the maximum number of files in short sequence to exclude days (default: {default_short_seq_threshold}): ").strip()
+    short_seq_threshold = int(short_seq_threshold_input) if short_seq_threshold_input else default_short_seq_threshold
+    if short_seq_threshold > 0:
+        df.loc[df['short_sequence_count'] > short_seq_threshold, 'exclude'] = 1
+
+    # Check to exclude files based on criteria
+    exclude_criteria = CONFIG['behavior_flags']['exclude_creation_modified_criteria']
+    if not exclude_criteria:
+        exclude_criteria_input = input("Do you want to exclude files where the unified name is based on creation or modified dates? (Y/N): ").strip().lower()
+        exclude_criteria = exclude_criteria_input == 'y'
+    if exclude_criteria:
+        df.loc[df['criteria'].isin(['creation', 'modified']), 'exclude'] = 1
+
+
+def _confirm_copy_and_cleanup(df: pd.DataFrame, metadata_path: str) -> None:
+    """
+    Prompt to continue with copying, copy qualifying files, optionally delete
+    copied/discarded source files, then save the (possibly mutated) metadata
+    back to metadata_path.
+
+    Shared by main()'s "use existing metadata" and "fresh scan" flows (dedup:
+    audit issue #64).
+    """
+    # Check for confirmation to process files
+    continue_copy = CONFIG['behavior_flags']['continue_copy']
+    if not continue_copy:
+        continue_copy_input = input("Do you want to continue with copying the files? (Y/N): ").strip().lower()
+        continue_copy = continue_copy_input == 'y'
+    if not continue_copy:
+        logging.info("Process terminated by user before copying files")
+        return
+
+    # Proceed to copy files
+    logging.info("Copying files to destination folder")
+    copy_files(df)
+
+    # Check if user wants to delete the copied files
+    delete_files = CONFIG['behavior_flags']['auto_delete_copied_files']
+    if not delete_files:
+        delete_files_input = input("Do you want to delete the source files that were copied? (Y/N): ").strip().lower()
+        delete_files = delete_files_input == 'y'
+    if delete_files:
+        logging.info("Deleting source files that were copied")
+        delete_copied_files(df)
+
+    # Check if user wants to delete discarded files
+    delete_discarded = CONFIG['behavior_flags']['auto_delete_discarded_files']
+    if not delete_discarded:
+        delete_discarded_input = input("Do you want to delete the discarded files? (Y/N): ").strip().lower()
+        delete_discarded = delete_discarded_input == 'y'
+    if delete_discarded:
+        logging.info("Deleting discarded files")
+        delete_discarded_files(df)
+
+    # Save updated metadata
+    df.to_excel(metadata_path, index=False)
+    logging.info("Updated metadata saved to %s", metadata_path)
+    logging.info("Process completed")
+
+
 # Call this function at the beginning of your main function
 def main(source_folder: str, dest_folder: str) -> None:
     # Set up logging to save log file in the destination folder
@@ -615,75 +697,14 @@ def main(source_folder: str, dest_folder: str) -> None:
                 recalculate_logic = recalculate_logic_input == 'y'
             if recalculate_logic:
                 df = recalculate_metadata(df)
-
-                # Display top unified days
-                top_days = df['unified_day'].value_counts().head(20)
-                for idx, (day, count) in enumerate(top_days.items(), start=1):
-                    logging.info("#{:02d} - {} - {} files".format(idx, day, count))
-
-                # Ask for exclusion threshold
-                default_exclude_threshold = CONFIG['processing_thresholds']['exclude_days_over_files']
-                exclude_threshold_input = input(f"Do you want to exclude days with more than X files? Enter X value, or zero if you don't want to exclude any file (default: {default_exclude_threshold}): ").strip()
-                exclude_threshold = int(exclude_threshold_input) if exclude_threshold_input else default_exclude_threshold
-                if exclude_threshold > 0:
-                    df.loc[df['total_files_unified_day'] > exclude_threshold, 'exclude'] = 1
-
-                # Ask for short sequence exclusion threshold
-                default_short_seq_threshold = CONFIG['processing_thresholds']['exclude_short_sequences_over']
-                short_seq_threshold_input = input(f"Enter the maximum number of files in short sequence to exclude days (default: {default_short_seq_threshold}): ").strip()
-                short_seq_threshold = int(short_seq_threshold_input) if short_seq_threshold_input else default_short_seq_threshold
-                if short_seq_threshold > 0:
-                    df.loc[df['short_sequence_count'] > short_seq_threshold, 'exclude'] = 1
-
-                # Check to exclude files based on criteria
-                exclude_criteria = CONFIG['behavior_flags']['exclude_creation_modified_criteria']
-                if not exclude_criteria:
-                    exclude_criteria_input = input("Do you want to exclude files where the unified name is based on creation or modified dates? (Y/N): ").strip().lower()
-                    exclude_criteria = exclude_criteria_input == 'y'
-                if exclude_criteria:
-                    df.loc[df['criteria'].isin(['creation', 'modified']), 'exclude'] = 1
+                _apply_exclusion_thresholds(df)
 
                 current_time_str = datetime.now().strftime('%Y%m%d-%H%M')
                 metadata_file = os.path.join(dest_folder, f'metadata_{current_time_str}.xlsx')
                 df.to_excel(metadata_file, index=False)
                 logging.info("Recalculated metadata and saved to %s", metadata_file)
 
-            # Check for confirmation to process files
-            continue_copy = CONFIG['behavior_flags']['continue_copy']
-            if not continue_copy:
-                continue_copy_input = input("Do you want to continue with copying the files? (Y/N): ").strip().lower()
-                continue_copy = continue_copy_input == 'y'
-            if not continue_copy:
-                logging.info("Process terminated by user before copying files")
-                return
-
-            # Proceed to copy files
-            logging.info("Copying files to destination folder")
-            copy_files(df)
-            logging.info("Process completed")
-
-            # Check if user wants to delete the copied files
-            delete_files = CONFIG['behavior_flags']['auto_delete_copied_files']
-            if not delete_files:
-                delete_files_input = input("Do you want to delete the source files that were copied? (Y/N): ").strip().lower()
-                delete_files = delete_files_input == 'y'
-            if delete_files:
-                logging.info("Deleting source files that were copied")
-                delete_copied_files(df)
-
-            # Check if user wants to delete discarded files
-            delete_discarded = CONFIG['behavior_flags']['auto_delete_discarded_files']
-            if not delete_discarded:
-                delete_discarded_input = input("Do you want to delete the discarded files? (Y/N): ").strip().lower()
-                delete_discarded = delete_discarded_input == 'y'
-            if delete_discarded:
-                logging.info("Deleting discarded files")
-                delete_discarded_files(df)
-
-            # Save updated metadata
-            df.to_excel(metadata_file, index=False)
-            logging.info("Updated metadata saved to %s", metadata_file)
-
+            _confirm_copy_and_cleanup(df, metadata_file)
             return
         else:
             logging.info("No file selected. Exiting.")
@@ -723,32 +744,7 @@ def main(source_folder: str, dest_folder: str) -> None:
     logging.info("Identifying duplicates")
     df = mark_duplicates(df)
 
-    # Display top unified days
-    top_days = df['unified_day'].value_counts().head(20)
-    for idx, (day, count) in enumerate(top_days.items(), start=1):
-        logging.info("#{:02d} - {} - {} files".format(idx, day, count))
-
-    # Ask for exclusion threshold
-    default_exclude_threshold = CONFIG['processing_thresholds']['exclude_days_over_files']
-    exclude_threshold_input = input(f"Do you want to exclude days with more than X files? Enter X value, or zero if you don't want to exclude any file (default: {default_exclude_threshold}): ").strip()
-    exclude_threshold = int(exclude_threshold_input) if exclude_threshold_input else default_exclude_threshold
-    if exclude_threshold > 0:
-        df.loc[df['total_files_unified_day'] > exclude_threshold, 'exclude'] = 1
-
-    # Ask for short sequence exclusion threshold
-    default_short_seq_threshold = CONFIG['processing_thresholds']['exclude_short_sequences_over']
-    short_seq_threshold_input = input(f"Enter the maximum number of files in short sequence to exclude days (default: {default_short_seq_threshold}): ").strip()
-    short_seq_threshold = int(short_seq_threshold_input) if short_seq_threshold_input else default_short_seq_threshold
-    if short_seq_threshold > 0:
-        df.loc[df['short_sequence_count'] > short_seq_threshold, 'exclude'] = 1
-
-    # Check to exclude files based on criteria
-    exclude_criteria = CONFIG['behavior_flags']['exclude_creation_modified_criteria']
-    if not exclude_criteria:
-        exclude_criteria_input = input("Do you want to exclude files where the unified name is based on creation or modified dates? (Y/N): ").strip().lower()
-        exclude_criteria = exclude_criteria_input == 'y'
-    if exclude_criteria:
-        df.loc[df['criteria'].isin(['creation', 'modified']), 'exclude'] = 1
+    _apply_exclusion_thresholds(df)
 
     # Save inventory to Excel before copying
     logging.info("Saving inventory to Excel")
@@ -756,42 +752,7 @@ def main(source_folder: str, dest_folder: str) -> None:
     df.to_excel(excel_path, index=False)
     logging.info("Inventory saved to %s", excel_path)
 
-    # Check to continue with copying
-    continue_copy = CONFIG['behavior_flags']['continue_copy']
-    if not continue_copy:
-        continue_copy_input = input("Do you want to continue with copying the files? (Y/N): ").strip().lower()
-        continue_copy = continue_copy_input == 'y'
-    if not continue_copy:
-        logging.info("Process terminated by user before copying files")
-        return
-
-    # Copy qualifying files to destination with unified naming
-    logging.info("Copying files to destination")
-    copy_files(df)
-
-    # Check if user wants to delete the copied files
-    delete_files = CONFIG['behavior_flags']['auto_delete_copied_files']
-    if not delete_files:
-        delete_files_input = input("Do you want to delete the source files that were copied? (Y/N): ").strip().lower()
-        delete_files = delete_files_input == 'y'
-    if delete_files:
-        logging.info("Deleting source files that were copied")
-        delete_copied_files(df)
-
-    # Check if user wants to delete discarded files before copying
-    delete_discarded = CONFIG['behavior_flags']['auto_delete_discarded_files']
-    if not delete_discarded:
-        delete_discarded_input = input("Do you want to delete the discarded files? (Y/N): ").strip().lower()
-        delete_discarded = delete_discarded_input == 'y'
-    if delete_discarded:
-        logging.info("Deleting discarded files")
-        delete_discarded_files(df)
-
-    # Save updated metadata
-    df.to_excel(excel_path, index=False)
-    logging.info("Updated metadata saved to %s", excel_path)
-
-    logging.info("Process completed")
+    _confirm_copy_and_cleanup(df, excel_path)
 
 if __name__ == "__main__":
     try:

--- a/image/png_to_jpg_converter.py
+++ b/image/png_to_jpg_converter.py
@@ -1,23 +1,10 @@
-import tkinter as tk
-from tkinter import filedialog, messagebox
 from PIL import Image, UnidentifiedImageError
-import os
 from pathlib import Path
 import logging
 
+from _image_to_jpg_converter import select_folder, convert_folder_to_jpg, show_completion_messagebox
+
 logger = logging.getLogger(__name__)
-
-def select_folder() -> str:
-    """Open folder dialog and return selected folder path"""
-    root = tk.Tk()
-    root.withdraw()  # Hide the main window
-
-    folder_path = filedialog.askdirectory(
-        title="Select folder containing PNG images"
-    )
-
-    root.destroy()
-    return folder_path
 
 def validate_image_file(file_path: Path) -> bool:
     """Validate if a file is a valid image that can be opened"""
@@ -30,82 +17,35 @@ def validate_image_file(file_path: Path) -> bool:
         logger.error("Cannot identify image file '%s': %s", file_path, e)
         return False
 
+def _png_to_rgb(img: "Image.Image") -> "Image.Image":
+    """Convert to RGB if necessary (JPG doesn't support transparency)."""
+    if img.mode in ('RGBA', 'LA', 'P'):
+        # Create white background for transparent images
+        background = Image.new('RGB', img.size, (255, 255, 255))
+        if img.mode == 'P':
+            img = img.convert('RGBA')
+        background.paste(img, mask=img.split()[-1] if img.mode == 'RGBA' else None)
+        img = background
+    elif img.mode != 'RGB':
+        img = img.convert('RGB')
+    return img
+
+
 def convert_png_to_jpg(folder_path: str) -> None:
     """Convert all PNG images in the folder to JPG format with improved error handling"""
-    if not folder_path:
-        logger.info("No folder selected.")
-        return
-
-    folder = Path(folder_path)
-    if not folder.exists():
-        logger.error("Folder does not exist: %s", folder_path)
-        return
-
-    # Find all PNG files in the folder (case insensitive)
-    png_files = []
-    for file in folder.iterdir():
-        if file.is_file() and file.suffix.lower() == '.png':
-            png_files.append(file)
-
-    if not png_files:
-        logger.info("No PNG files found in the selected folder.")
-        return
-
-    converted_count = 0
-    error_count = 0
-
-    logger.info("Found %d PNG files in %s", len(png_files), folder_path)
-    logger.info("Starting conversion...")
-
-    for png_file in png_files:
-        # Validate the image file first
-        if not validate_image_file(png_file):
-            logger.warning("Skipping %s - invalid or corrupted image file", png_file.name)
-            error_count += 1
-            continue
-
-        # Create JPG filename with same name but .jpg extension
-        jpg_file = png_file.with_suffix('.jpg')
-
-        try:
-            # Open PNG image with explicit format
-            with Image.open(png_file) as img:
-                # Force load the image data
-                img.load()
-
-                # Convert to RGB if necessary (JPG doesn't support transparency)
-                if img.mode in ('RGBA', 'LA', 'P'):
-                    # Create white background for transparent images
-                    background = Image.new('RGB', img.size, (255, 255, 255))
-                    if img.mode == 'P':
-                        img = img.convert('RGBA')
-                    background.paste(img, mask=img.split()[-1] if img.mode == 'RGBA' else None)
-                    img = background
-                elif img.mode != 'RGB':
-                    img = img.convert('RGB')
-
-                # Save as JPG with explicit format
-                img.save(jpg_file, 'JPEG', quality=95, optimize=True)
-                logger.info("Converted %s -> %s", png_file.name, jpg_file.name)
-                converted_count += 1
-
-        except UnidentifiedImageError as e:
-            logger.error("Error: Cannot identify image file '%s': %s", png_file, e)
-            error_count += 1
-        except OSError as e:
-            logger.error("Error: OS error processing '%s': %s", png_file, e)
-            error_count += 1
-        except Exception as e:
-            logger.error("Error converting %s: %s", png_file.name, e)
-            error_count += 1
-
-    logger.info("Conversion complete!")
-    logger.info("Converted: %d files", converted_count)
-    logger.info("Errors: %d files", error_count)
-
-    if error_count > 0:
-        logger.info("Note: %d files had errors and were skipped.", error_count)
-        logger.info("This could be due to corrupted files, unsupported formats, or permission issues.")
+    convert_folder_to_jpg(
+        folder_path,
+        source_extensions=['.png'],
+        validate_fn=validate_image_file,
+        convert_to_rgb_fn=_png_to_rgb,
+        save_kwargs={'quality': 95, 'optimize': True},
+        # Note: unlike heic_to_jpg_converter.py, this does NOT protect an
+        # existing same-named .jpg from being overwritten - preserved as-is
+        # (pre-existing behavior, not something this dedup changes).
+        skip_existing_jpg=False,
+        logger=logger,
+        kind_label='PNG',
+    )
 
 def main() -> None:
     """Main function to run the PNG to JPG converter"""
@@ -114,20 +54,17 @@ def main() -> None:
     logger.info("=" * 40)
 
     # Select folder
-    folder_path = select_folder()
+    folder_path = select_folder("Select folder containing PNG images")
 
     if folder_path:
         # Convert PNG files to JPG
         convert_png_to_jpg(folder_path)
 
         # Show completion message
-        root = tk.Tk()
-        root.withdraw()
-        messagebox.showinfo(
+        show_completion_messagebox(
             "Conversion Complete",
-            f"PNG to JPG conversion completed!\n\nCheck the selected folder for converted files."
+            "PNG to JPG conversion completed!\n\nCheck the selected folder for converted files."
         )
-        root.destroy()
     else:
         logger.info("No folder selected. Exiting.")
 

--- a/notion/build_newsletter.py
+++ b/notion/build_newsletter.py
@@ -12,7 +12,6 @@ Usage:
 
 import argparse
 import re
-import json
 import logging
 import os
 import sys
@@ -20,6 +19,8 @@ import webbrowser
 from typing import Dict, List, Optional, Sequence, Tuple
 import requests
 from dotenv import load_dotenv
+
+import utils as notion_utils
 
 # Load environment variables
 load_dotenv()
@@ -61,55 +62,14 @@ class NotionNewsletterBuilder:
     
     def _load_config(self, config_path: str) -> Dict:
         """Load and parse the JSON configuration file."""
-        try:
-            with open(config_path, 'r') as f:
-                return json.load(f)
-        except FileNotFoundError:
-            # Try looking in the same directory as this script
-            script_dir = os.path.dirname(os.path.abspath(__file__))
-            fallback_path = os.path.join(script_dir, os.path.basename(config_path))
-            try:
-                with open(fallback_path, 'r') as f:
-                    logging.info(f"📁 Loaded config from fallback path: {fallback_path}")
-                    return json.load(f)
-            except FileNotFoundError:
-                raise FileNotFoundError(f"Configuration file not found at {config_path} or {fallback_path}")
-            except json.JSONDecodeError:
-                raise ValueError(f"Invalid JSON in fallback configuration file: {fallback_path}")
-        except json.JSONDecodeError:
-            raise ValueError(f"Invalid JSON in configuration file: {config_path}")
-    
+        return notion_utils.load_json_config_with_fallback(config_path, __file__)
+
     def _query_notion_database(self, database_id: str, filter_data: Optional[Dict] = None) -> List[Dict]:
         """Query a Notion database with optional filtering."""
-        url = f"https://api.notion.com/v1/databases/{database_id}/query"
-        
         payload = {}
         if filter_data:
             payload['filter'] = filter_data
-        
-        all_results = []
-        has_more = True
-        start_cursor = None
-        
-        while has_more:
-            if start_cursor:
-                payload['start_cursor'] = start_cursor
-            
-            try:
-                response = requests.post(url, headers=self.headers, json=payload)
-                response.raise_for_status()
-                
-                data = response.json()
-                all_results.extend(data.get('results', []))
-                
-                has_more = data.get('has_more', False)
-                start_cursor = data.get('next_cursor')
-                
-            except requests.exceptions.RequestException as e:
-                logging.error(f"❌ Failed to query Notion database: {e}")
-                raise
-        
-        return all_results
+        return notion_utils.paginated_database_query(self.headers, database_id, payload)
     
     def find_newsletter_by_title(self, newsletter_title: str) -> Optional[Dict]:
         """Find a newsletter record by its number."""
@@ -150,51 +110,47 @@ class NotionNewsletterBuilder:
         """Extract name, URL, topic, star, and niche from an article record."""
         try:
             properties = article.get('properties', {})
-            
-            # Extract title
+
+            # Extract title. Note: unlike notion_utils.extract_title_text (which joins
+            # every rich-text segment), this intentionally keeps only the FIRST segment's
+            # plain_text - preserved as-is to avoid a behavior change (see issue #64 notes).
             title_prop = properties.get('article', {})
-            if title_prop.get('type') == 'title':
-                title_content = title_prop.get('title', [])
-                if not title_content:
-                    return None
-                name = title_content[0].get('plain_text', '').strip()
-            else:
+            if title_prop.get('type') != 'title':
                 return None
-            
+            title_content = title_prop.get('title', [])
+            if not title_content:
+                return None
+            name = title_content[0].get('plain_text', '').strip()
+
             # Extract URL
             url_prop = properties.get('link', {})
-            if url_prop.get('type') == 'url':
-                url = url_prop.get('url', '').strip()
-                if not url:
-                    return None
-            else:
+            if url_prop.get('type') != 'url':
                 return None
-            
+            url = notion_utils.extract_url(url_prop).strip()
+            if not url:
+                return None
+
             # Extract topic
             topic_prop = properties.get('topic', {})
-            if topic_prop.get('type') == 'select':
-                topic_obj = topic_prop.get('select')
-                if not topic_obj:
-                    return None
-                topic = topic_obj.get('name', '').strip()
-            else:
+            if topic_prop.get('type') != 'select':
                 return None
-            
+            topic = notion_utils.extract_select_name(topic_prop).strip()
+            if not topic:
+                return None
+
             # Extract star (checkbox)
             star_prop = properties.get('star', {})
-            star = False
-            if star_prop.get('type') == 'checkbox':
-                star = star_prop.get('checkbox', False)
-            
+            star = notion_utils.extract_checkbox(star_prop) if star_prop.get('type') == 'checkbox' else False
+
             # Extract niche (multi_select)
             niche_prop = properties.get('niche', {})
-            niche = []
             if niche_prop.get('type') == 'multi_select':
-                niche_objs = niche_prop.get('multi_select', [])
-                niche = [obj.get('name', '').strip() for obj in niche_objs if obj.get('name')]
-            
+                niche = [n.strip() for n in notion_utils.extract_multi_select_names(niche_prop) if n]
+            else:
+                niche = []
+
             return name, url, topic, star, niche
-            
+
         except Exception as e:
             logging.error(f"❌ Error extracting data from article: {e}")
             return None

--- a/notion/journal_automation.py
+++ b/notion/journal_automation.py
@@ -6,9 +6,8 @@ import sys
 from datetime import datetime, timedelta
 from typing import Any, Optional
 
-import requests
-
 from utils import load_env_variables, load_json_config
+import utils as notion_utils
 
 logger = logging.getLogger(__name__)
 
@@ -76,7 +75,7 @@ def query_notion_database(
     start_iso = start_date.isoformat()
     end_iso = end_date.isoformat()
 
-    filter_body = {
+    query_body = {
         "filter": {
             "and": [
                 {
@@ -100,80 +99,30 @@ def query_notion_database(
             }
         ]
     }
-    
-    pages = []
-    start_cursor = None
-    
-    while True:
-        if start_cursor:
-            filter_body["start_cursor"] = start_cursor
-        
-        try:
-            response = requests.post(
-                f"https://api.notion.com/v1/databases/{database_id}/query",
-                headers=headers,
-                json=filter_body
-            )
-            response.raise_for_status()
-            
-            data = response.json()
-            results = data.get('results', [])
-            
-            if not results:
-                break
-            
-            pages.extend(results)
-            logger.info("📥 Retrieved %s entries (total: %s)", len(results), len(pages))
 
-            if not data.get("has_more", False):
-                break
+    return notion_utils.paginated_database_query(headers, database_id, query_body)
 
-            start_cursor = data.get("next_cursor")
+# Property types this extractor knows how to render as a display string.
+# Anything else (e.g. url, number, relation) falls through to "" - matches
+# the pre-dedup behavior, which only ever handled these six types.
+_HANDLED_PROPERTY_TYPES = {'title', 'rich_text', 'multi_select', 'select', 'checkbox', 'date'}
 
-        except requests.exceptions.RequestException as e:
-            logger.error("❌ Notion API error: %s", e)
-            if getattr(e, "response", None):
-                logger.error("📊 Status: %s", e.response.status_code)
-                logger.error("Response: %s", (e.response.text or "")[:500])
-            raise
-
-    return pages
 
 def extract_property_value(properties: dict[str, Any], property_name: str) -> str:
     """Extract string value from a Notion property, or empty string if missing."""
     prop = properties.get(property_name, {})
     prop_type = prop.get('type')
-    
-    if not prop_type:
+
+    if prop_type not in _HANDLED_PROPERTY_TYPES:
         return ""
-    
-    # Handle different property types
-    if prop_type == 'title':
-        title_content = prop.get('title', [])
-        return ''.join([segment.get('plain_text', '') for segment in title_content]).strip()
-    
-    elif prop_type == 'rich_text':
-        rich_text_content = prop.get('rich_text', [])
-        return ''.join([segment.get('plain_text', '') for segment in rich_text_content]).strip()
-    
-    elif prop_type == 'multi_select':
-        options = prop.get('multi_select', [])
-        return ', '.join([opt.get('name', '') for opt in options])
-    
-    elif prop_type == 'select':
-        option = prop.get('select', {})
-        return option.get('name', '') if option else ""
-    
-    elif prop_type == 'checkbox':
-        return "✓" if prop.get('checkbox', False) else ""
-    
-    elif prop_type == 'date':
-        date_obj = prop.get('date', {})
-        if date_obj:
-            return date_obj.get('start', '')
-        return ""
-    
-    return ""
+
+    value = notion_utils.extract_property(prop)
+
+    if isinstance(value, bool):
+        return "✓" if value else ""
+    if isinstance(value, list):
+        return ', '.join(value)
+    return value or ""
 
 def process_field_from_pages(pages: list[dict], field_config: dict[str, Any]) -> str:
     """Process one field from Notion pages; return formatted string with frequency counts."""

--- a/notion/normalize_names.py
+++ b/notion/normalize_names.py
@@ -12,7 +12,6 @@ Usage:
 """
 
 import argparse
-import json
 import logging
 import os
 import re
@@ -22,6 +21,8 @@ from typing import Dict, List, Optional, Tuple, Any
 
 import requests
 from dotenv import load_dotenv
+
+import utils as notion_utils
 
 # Load environment variables from root .env file
 load_dotenv()
@@ -50,17 +51,7 @@ class NotionNameNormalizer:
     
     def _setup_api_credentials(self):
         """Setup API credentials and headers."""
-        self.notion_api_key = os.getenv('NOTION_API_TOKEN') or self.config.get('notion_api_key')
-        self.database_id = self.config.get('database_id')
-        
-        if not all([self.notion_api_key, self.database_id]):
-            raise ValueError("Missing required configuration values: notion_api_key and database_id")
-        
-        self.headers = {
-            'Authorization': f'Bearer {self.notion_api_key}',
-            'Notion-Version': '2022-06-28',
-            'Content-Type': 'application/json'
-        }
+        self.notion_api_key, self.database_id, self.headers = notion_utils.resolve_notion_credentials(self.config)
     
     def _load_word_lists(self):
         """Load word lists from configuration."""
@@ -92,74 +83,21 @@ class NotionNameNormalizer:
     
     def _load_config(self, config_path: str) -> Dict:
         """Load and parse the JSON configuration file."""
-        paths_to_try = [
-            config_path,
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.basename(config_path))
-        ]
-        
-        for path in paths_to_try:
-            try:
-                with open(path, 'r') as f:
-                    config = json.load(f)
-                if path != config_path:
-                    logging.info(f"📁 Loaded config from fallback path: {path}")
-                return config
-            except FileNotFoundError:
-                continue
-            except json.JSONDecodeError:
-                raise ValueError(f"Invalid JSON in configuration file: {path}")
-        
-        raise FileNotFoundError(f"Configuration file not found at {' or '.join(paths_to_try)}")
-    
+        return notion_utils.load_json_config_with_fallback(config_path, __file__)
+
     def _query_notion_database(self, days: int) -> List[Dict]:
         """Query Notion database for articles created in the last N days."""
         filter_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
         filter_date_str = filter_date.isoformat() + 'Z'
-        
+
         logging.info(f"🔍 Querying database for articles from last {days} days (since {filter_date_str})")
-        
-        filter_body = {
+
+        query_body = {
             "filter": {"and": [{"property": "created", "created_time": {"after": filter_date_str}}]},
             "sorts": [{"property": "created", "direction": "descending"}]
         }
-        
-        pages = []
-        start_cursor = None
-        
-        while True:
-            if start_cursor:
-                filter_body["start_cursor"] = start_cursor
-            
-            try:
-                response = requests.post(
-                    f"https://api.notion.com/v1/databases/{self.database_id}/query",
-                    headers=self.headers,
-                    json=filter_body
-                )
-                response.raise_for_status()
-                
-                data = response.json()
-                results = data.get('results', [])
-                
-                if not results:
-                    break
-                
-                pages.extend(results)
-                logging.debug(f"📥 Retrieved {len(results)} pages (total: {len(pages)})")
-                
-                if not data.get('has_more', False):
-                    break
-                
-                start_cursor = data.get('next_cursor')
-                
-            except requests.exceptions.RequestException as e:
-                logging.error(f"❌ Notion API error: {e}")
-                if hasattr(e, 'response') and e.response:
-                    logging.error(f"📊 Status: {e.response.status_code}, Response: {e.response.text[:200]}...")
-                raise
-        
-        logging.info(f"📊 Total pages retrieved: {len(pages)}")
-        return pages
+
+        return notion_utils.paginated_database_query(self.headers, self.database_id, query_body)
     
     def _extract_page_info(self, page: Dict) -> Optional[Tuple[str, str, str]]:
         """Extract essential information from a Notion page object."""

--- a/notion/normalize_url.py
+++ b/notion/normalize_url.py
@@ -12,7 +12,6 @@ Usage:
 """
 
 import argparse
-import json
 import logging
 import os
 import sys
@@ -22,6 +21,8 @@ from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 
 import requests
 from dotenv import load_dotenv
+
+import utils as notion_utils
 
 # Load environment variables
 load_dotenv()
@@ -41,17 +42,7 @@ class NotionURLNormalizer:
     
     def _setup_api_credentials(self):
         """Setup API credentials and headers."""
-        self.notion_api_key = os.getenv('NOTION_API_TOKEN') or self.config.get('notion_api_key')
-        self.database_id = self.config.get('database_id')
-        
-        if not all([self.notion_api_key, self.database_id]):
-            raise ValueError("Missing required configuration values: notion_api_key and database_id")
-        
-        self.headers = {
-            'Authorization': f'Bearer {self.notion_api_key}',
-            'Notion-Version': '2022-06-28',
-            'Content-Type': 'application/json'
-        }
+        self.notion_api_key, self.database_id, self.headers = notion_utils.resolve_notion_credentials(self.config)
     
     def _log_initialization(self):
         """Log initialization summary."""
@@ -61,24 +52,7 @@ class NotionURLNormalizer:
 
     def _load_config(self, config_path: str) -> Dict:
         """Load and parse the JSON configuration file."""
-        paths_to_try = [
-            config_path,
-            os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.basename(config_path))
-        ]
-        
-        for path in paths_to_try:
-            try:
-                with open(path, 'r') as f:
-                    config = json.load(f)
-                if path != config_path:
-                    logging.info(f"📁 Loaded config from fallback path: {path}")
-                return config
-            except FileNotFoundError:
-                continue
-            except json.JSONDecodeError:
-                raise ValueError(f"Invalid JSON in configuration file: {path}")
-        
-        raise FileNotFoundError(f"Configuration file not found at {' or '.join(paths_to_try)}")
+        return notion_utils.load_json_config_with_fallback(config_path, __file__)
 
     def _clean_url(self, original_url: str) -> str:
         """
@@ -149,51 +123,15 @@ class NotionURLNormalizer:
         """Query Notion database for articles created in the last N days."""
         filter_date = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
         filter_date_str = filter_date.isoformat() + 'Z'
-        
+
         logging.info(f"🔍 Querying database for articles from last {days} days (since {filter_date_str})")
-        
-        filter_body = {
+
+        query_body = {
             "filter": {"and": [{"property": "created", "created_time": {"after": filter_date_str}}]},
             "sorts": [{"property": "created", "direction": "descending"}]
         }
-        
-        pages = []
-        start_cursor = None
-        
-        while True:
-            if start_cursor:
-                filter_body["start_cursor"] = start_cursor
-            
-            try:
-                response = requests.post(
-                    f"https://api.notion.com/v1/databases/{self.database_id}/query",
-                    headers=self.headers,
-                    json=filter_body
-                )
-                response.raise_for_status()
-                
-                data = response.json()
-                results = data.get('results', [])
-                
-                if not results:
-                    break
-                
-                pages.extend(results)
-                logging.debug(f"📥 Retrieved {len(results)} pages (total: {len(pages)})")
-                
-                if not data.get('has_more', False):
-                    break
-                
-                start_cursor = data.get('next_cursor')
-                
-            except requests.exceptions.RequestException as e:
-                logging.error(f"❌ Notion API error: {e}")
-                if hasattr(e, 'response') and e.response:
-                    logging.error(f"📊 Status: {e.response.status_code}, Response: {e.response.text[:200]}...")
-                raise
-        
-        logging.info(f"📊 Total pages retrieved: {len(pages)}")
-        return pages
+
+        return notion_utils.paginated_database_query(self.headers, self.database_id, query_body)
 
     def _extract_page_info(self, page: Dict) -> Optional[Tuple[str, str, str]]:
         """Extract essential information (ID, time, URL) from a Notion page object."""

--- a/notion/sample_illustrations.py
+++ b/notion/sample_illustrations.py
@@ -20,7 +20,6 @@ Usage:
 """
 
 import argparse
-import json
 import logging
 import os
 import re
@@ -32,6 +31,8 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 import requests
 from dotenv import load_dotenv
+
+import utils as notion_utils
 
 load_dotenv()
 
@@ -46,20 +47,7 @@ WINDOWS_ILLEGAL = re.compile(r'[<>:"/\\|?*]')
 
 
 def load_config(config_path: str) -> Dict[str, Any]:
-    paths_to_try = [
-        config_path,
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.basename(config_path)),
-    ]
-    for path in paths_to_try:
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                config = json.load(f)
-            if path != config_path:
-                logging.info(f"Loaded config from fallback path: {path}")
-            return config
-        except FileNotFoundError:
-            continue
-    raise FileNotFoundError(f"Config not found at {' or '.join(paths_to_try)}")
+    return notion_utils.load_json_config_with_fallback(config_path, __file__)
 
 
 def resolve_token(config: Dict[str, Any]) -> str:
@@ -91,25 +79,16 @@ def query_database(db_id: str, headers: Dict[str, str]) -> List[Dict[str, Any]]:
     return pages
 
 
-def extract_title(prop: Dict[str, Any]) -> str:
-    return "".join(s.get("plain_text", "") for s in prop.get("title", [])).strip()
-
-
-def extract_rich_text(prop: Dict[str, Any]) -> str:
-    return "".join(s.get("plain_text", "") for s in prop.get("rich_text", [])).strip()
-
-
-def extract_relation_ids(prop: Dict[str, Any]) -> List[str]:
-    return [r["id"] for r in prop.get("relation", [])]
-
-
-def extract_multi_select(prop: Dict[str, Any]) -> List[str]:
-    return [x["name"] for x in prop.get("multi_select", [])]
+# Thin aliases onto the shared notion/utils.py extractors (dedup: issue #64).
+extract_title = notion_utils.extract_title_text
+extract_rich_text = notion_utils.extract_rich_text_value
+extract_relation_ids = notion_utils.extract_relation_ids
+extract_multi_select = notion_utils.extract_multi_select_names
 
 
 def extract_select(prop: Dict[str, Any]) -> Optional[str]:
-    sel = prop.get("select")
-    return sel["name"] if sel else None
+    """Selected option's name, or None if unset (this caller's convention)."""
+    return notion_utils.extract_select_name(prop) or None
 
 
 def build_concepts_map(pages: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:

--- a/notion/utils.py
+++ b/notion/utils.py
@@ -13,8 +13,9 @@ from pathlib import Path
 from datetime import datetime
 from zipfile import BadZipFile
 import json
+import requests
 from dotenv import load_dotenv
-from typing import Optional, Dict, List, Any
+from typing import Optional, Dict, List, Any, Tuple
 
 log = logging.getLogger(__name__)
 
@@ -292,3 +293,186 @@ def load_excel_with_json_and_export(excel_path: str, column_name: str) -> None:
 
     # Log the resulting DataFrame head
     log.debug("%s", dict_df.head())
+
+
+# ---------------------------------------------------------------------------
+# Shared Notion API helpers (dedup: audit issue #64)
+#
+# These consolidate logic that was independently reimplemented across
+# build_newsletter.py, normalize_names.py, normalize_url.py,
+# journal_automation.py, and sample_illustrations.py.
+# ---------------------------------------------------------------------------
+
+NOTION_VERSION = "2022-06-28"
+
+
+def build_notion_headers(api_key: str) -> Dict[str, str]:
+    """Standard Notion API request headers."""
+    return {
+        'Authorization': f'Bearer {api_key}',
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json'
+    }
+
+
+def resolve_notion_credentials(config: Dict[str, Any]) -> Tuple[str, str, Dict[str, str]]:
+    """Resolve (api_key, database_id, headers) from a loaded config dict / env.
+
+    Mirrors the identical `_setup_api_credentials` previously duplicated in
+    normalize_names.py and normalize_url.py. Raises ValueError if either the
+    API key or the database_id can't be resolved.
+    """
+    api_key = os.getenv('NOTION_API_TOKEN') or config.get('notion_api_key')
+    database_id = config.get('database_id')
+
+    if not all([api_key, database_id]):
+        raise ValueError("Missing required configuration values: notion_api_key and database_id")
+
+    return api_key, database_id, build_notion_headers(api_key)
+
+
+def load_json_config_with_fallback(config_path: str, caller_file: str) -> Dict[str, Any]:
+    """Load a JSON config file, falling back to caller_file's own directory.
+
+    Mirrors the "try config_path, then try alongside the calling script" pattern
+    previously duplicated in build_newsletter.py, normalize_names.py,
+    normalize_url.py, and sample_illustrations.py.
+    """
+    paths_to_try = [
+        config_path,
+        os.path.join(os.path.dirname(os.path.abspath(caller_file)), os.path.basename(config_path)),
+    ]
+
+    for path in paths_to_try:
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+            if path != config_path:
+                log.info("📁 Loaded config from fallback path: %s", path)
+            return config
+        except FileNotFoundError:
+            continue
+        except json.JSONDecodeError:
+            raise ValueError(f"Invalid JSON in configuration file: {path}")
+
+    raise FileNotFoundError(f"Configuration file not found at {' or '.join(paths_to_try)}")
+
+
+def paginated_database_query(
+    headers: Dict[str, str],
+    database_id: str,
+    query_body: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """POST a Notion `databases.query`, following `has_more`/`next_cursor` pagination.
+
+    `query_body` may carry any combination of 'filter' / 'sorts' / 'page_size' (or
+    none); it is not mutated in place, a per-page copy receives 'start_cursor'.
+
+    Consolidates the paginated-query loop previously duplicated (with an
+    identical POST / has_more / next_cursor / error-branch shape) across
+    build_newsletter.py, normalize_names.py, normalize_url.py, and
+    journal_automation.py.
+    """
+    url = f"https://api.notion.com/v1/databases/{database_id}/query"
+    payload: Dict[str, Any] = dict(query_body) if query_body else {}
+
+    all_results: List[Dict[str, Any]] = []
+    has_more = True
+    start_cursor = None
+
+    while has_more:
+        if start_cursor:
+            payload['start_cursor'] = start_cursor
+
+        try:
+            response = requests.post(url, headers=headers, json=payload)
+            response.raise_for_status()
+
+            data = response.json()
+            results = data.get('results', [])
+            all_results.extend(results)
+            log.debug("📥 Retrieved %s pages (total: %s)", len(results), len(all_results))
+
+            has_more = data.get('has_more', False)
+            start_cursor = data.get('next_cursor')
+
+        except requests.exceptions.RequestException as e:
+            log.error("❌ Failed to query Notion database: %s", e)
+            if getattr(e, 'response', None):
+                log.error("📊 Status: %s, Response: %s...", e.response.status_code, (e.response.text or '')[:200])
+            raise
+
+    log.info("📊 Total pages retrieved: %s", len(all_results))
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# Shared Notion property-value extraction (dedup: audit issue #64)
+#
+# Consolidates the "title / rich_text / select / multi_select / date /
+# checkbox / url" extraction reimplemented across build_newsletter.py,
+# journal_automation.py, sample_illustrations.py, and
+# articles_sync/notion_articles_sync.py.
+# ---------------------------------------------------------------------------
+
+def extract_title_text(prop: Dict[str, Any]) -> str:
+    """Join all rich-text segments of a 'title' property into plain text."""
+    return ''.join(s.get('plain_text', '') for s in prop.get('title', [])).strip()
+
+
+def extract_rich_text_value(prop: Dict[str, Any]) -> str:
+    """Join all rich-text segments of a 'rich_text' property into plain text."""
+    return ''.join(s.get('plain_text', '') for s in prop.get('rich_text', [])).strip()
+
+
+def extract_select_name(prop: Dict[str, Any]) -> str:
+    """Selected option's name, or '' if unset."""
+    option = prop.get('select')
+    return option.get('name', '') if option else ''
+
+
+def extract_multi_select_names(prop: Dict[str, Any]) -> List[str]:
+    """Names of all selected multi_select options (unfiltered, unstripped)."""
+    return [opt.get('name', '') for opt in prop.get('multi_select', [])]
+
+
+def extract_relation_ids(prop: Dict[str, Any]) -> List[str]:
+    """Page ids of all related pages in a 'relation' property."""
+    return [r.get('id') for r in prop.get('relation', [])]
+
+
+def extract_checkbox(prop: Dict[str, Any]) -> bool:
+    """Checkbox state, defaulting to False."""
+    return prop.get('checkbox', False)
+
+
+def extract_date_start(prop: Dict[str, Any]) -> str:
+    """Start date/time of a 'date' property, or '' if unset."""
+    date_obj = prop.get('date')
+    return date_obj.get('start', '') if date_obj else ''
+
+
+def extract_url(prop: Dict[str, Any]) -> str:
+    """URL value of a 'url' property, or '' if unset."""
+    return prop.get('url') or ''
+
+
+_PROPERTY_EXTRACTORS = {
+    'title': extract_title_text,
+    'rich_text': extract_rich_text_value,
+    'select': extract_select_name,
+    'multi_select': extract_multi_select_names,
+    'relation': extract_relation_ids,
+    'checkbox': extract_checkbox,
+    'date': extract_date_start,
+    'url': extract_url,
+}
+
+
+def extract_property(prop: Dict[str, Any]) -> Any:
+    """Extract the native Python value from a Notion property dict, dispatching
+    on its 'type' field. Returns None for a type this helper doesn't know about
+    (callers that need a different default should check `prop.get('type')` first).
+    """
+    extractor = _PROPERTY_EXTRACTORS.get(prop.get('type'))
+    return extractor(prop) if extractor else None

--- a/system/apple/_vcard_fields.py
+++ b/system/apple/_vcard_fields.py
@@ -1,0 +1,52 @@
+"""
+Shared vCard TEL/EMAIL/ADR TYPE-label parsing.
+
+Consolidates the TYPE= extraction logic previously duplicated - and drifted -
+between unify_vcards.py (regex `TYPE=([^;:]+)`) and convert_to_apple.py
+(position-based split on the WHOLE line, which mis-parsed the common
+single-semicolon legacy shape like "TEL;HOME:+123" - because it split on
+";" before isolating the value from the prefix, "HOME:+123" ended up as the
+extracted type, or leaked into the reconstructed value for ADR - see the
+audit issue #64 dedup Notes for the concrete before/after traces).
+
+extract_type_label() implements unify_vcards.py's behavior (regex-first,
+correct per the vCard spec since TYPE= may appear anywhere in the property
+parameter list), falling back to the legacy positional convention
+(`PROPERTY;TYPE:VALUE`, using the second semicolon-separated segment of the
+*prefix only* - i.e. the part before the first ':') when no TYPE= parameter
+is present at all. Both callers must isolate `prefix` (everything before the
+first ':') before calling this - do not pass the whole raw line.
+"""
+
+import re
+from typing import Optional
+
+
+def extract_type_label(prefix: str, *, legacy_positional_fallback: bool = True) -> Optional[str]:
+    """
+    Extract the TYPE value from a vCard property prefix (the part before the
+    first ':'), e.g. "TEL;TYPE=HOME" -> "HOME", or the legacy "TEL;HOME" ->
+    "HOME". Returns None when neither shape matches - callers should leave
+    their own default type label untouched in that case (mirrors the
+    original per-field parsing's if/elif structure exactly).
+
+    legacy_positional_fallback: unify_vcards.py's original parsing only ever
+    applied the "second semicolon-separated segment" fallback for TEL, not
+    for EMAIL/ADR (which only ever matched the regex path) - pass False to
+    reproduce that narrower EMAIL/ADR behavior; leave True (the default) for
+    TEL, and for convert_to_apple.py's callers (which only invoke this once
+    they've already confirmed no TYPE= is present, so the fallback is the
+    only path that can fire there).
+    """
+    if "TYPE=" in prefix:
+        type_match = re.search(r'TYPE=([^;:]+)', prefix)
+        if type_match:
+            return type_match.group(1).upper()
+        return None
+
+    if legacy_positional_fallback and ";" in prefix:
+        parts = prefix.split(";")
+        if len(parts) > 1:
+            return parts[1].upper()
+
+    return None

--- a/system/apple/convert_to_apple.py
+++ b/system/apple/convert_to_apple.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import List, Dict, Any
 import re
 
+from _vcard_fields import extract_type_label
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -192,21 +194,24 @@ class AppleContactConverter:
             # Already properly formatted
             return line
         elif ";" in line and not "TYPE=" in line:
-            # Convert old format to new format
-            parts = line.split(";")
-            if len(parts) >= 2:
-                phone_type = parts[1].upper()
-                phone_number = parts[-1].split(":")[-1]
-                return f"TEL;TYPE={phone_type}:{phone_number}"
+            # Convert old format to new format. Isolate the prefix (before
+            # the first ':') from the value first, then extract the type
+            # from the prefix alone - not the whole line (dedup: audit issue
+            # #64; the old whole-line split embedded the value into the
+            # type string for the common single-semicolon shape, see Notes).
+            prefix, sep, value = line.partition(":")
+            phone_type = extract_type_label(prefix)
+            if phone_type:
+                return f"TEL;TYPE={phone_type}:{value}"
 
         return line
-    
+
     def _format_email_line(self, line: str) -> str:
         """Format email line for Apple compatibility.
-        
+
         Args:
             line: Original email line
-            
+
         Returns:
             Formatted email line
         """
@@ -214,20 +219,19 @@ class AppleContactConverter:
         if "TYPE=" in line and ";" in line:
             return line
         elif ";" in line and not "TYPE=" in line:
-            parts = line.split(";")
-            if len(parts) >= 2:
-                email_type = parts[1].upper()
-                email_address = parts[-1].split(":")[-1]
-                return f"EMAIL;TYPE={email_type}:{email_address}"
-        
+            prefix, sep, value = line.partition(":")
+            email_type = extract_type_label(prefix)
+            if email_type:
+                return f"EMAIL;TYPE={email_type}:{value}"
+
         return line
-    
+
     def _format_address_line(self, line: str) -> str:
         """Format address line for Apple compatibility.
-        
+
         Args:
             line: Original address line
-            
+
         Returns:
             Formatted address line
         """
@@ -235,12 +239,11 @@ class AppleContactConverter:
         if "TYPE=" in line and ";" in line:
             return line
         elif ";" in line and not "TYPE=" in line:
-            parts = line.split(";")
-            if len(parts) >= 2:
-                addr_type = parts[1].upper()
-                addr_parts = parts[2:]
-                return f"ADR;TYPE={addr_type}:{';'.join(addr_parts)}"
-        
+            prefix, sep, value = line.partition(":")
+            addr_type = extract_type_label(prefix)
+            if addr_type:
+                return f"ADR;TYPE={addr_type}:{value}"
+
         return line
     
     def _create_fn_from_n(self, n_line: str) -> str:

--- a/system/apple/unify_vcards.py
+++ b/system/apple/unify_vcards.py
@@ -18,6 +18,8 @@ import datetime
 import tkinter as tk
 from tkinter import filedialog
 
+from _vcard_fields import extract_type_label
+
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -239,15 +241,9 @@ class VCardParser:
             phone = ContactPhone(number=phone_number, original_line=line)
 
             # Extract type from prefix
-            if "TYPE=" in prefix:
-                type_match = re.search(r'TYPE=([^;:]+)', prefix)
-                if type_match:
-                    phone.type_label = type_match.group(1).upper()
-            elif ";" in prefix:
-                # Old format: TEL;HOME;+1234567890
-                parts = prefix.split(";")
-                if len(parts) > 1:
-                    phone.type_label = parts[1].upper()
+            type_label = extract_type_label(prefix)
+            if type_label is not None:
+                phone.type_label = type_label
 
             contact.phones.append(phone)
 
@@ -264,11 +260,11 @@ class VCardParser:
 
             email = ContactEmail(address=email_addr, original_line=line)
 
-            # Extract type from prefix
-            if "TYPE=" in prefix:
-                type_match = re.search(r'TYPE=([^;:]+)', prefix)
-                if type_match:
-                    email.type_label = type_match.group(1).upper()
+            # Extract type from prefix (no legacy-positional fallback for
+            # email, matching the original parsing - only TEL had that)
+            type_label = extract_type_label(prefix, legacy_positional_fallback=False)
+            if type_label is not None:
+                email.type_label = type_label
 
             contact.emails.append(email)
 
@@ -293,11 +289,11 @@ class VCardParser:
                 address.postal_code = addr_parts[5].strip()  # postal code
                 address.country = addr_parts[6].strip()  # country
 
-            # Extract type from prefix
-            if "TYPE=" in prefix:
-                type_match = re.search(r'TYPE=([^;:]+)', prefix)
-                if type_match:
-                    address.type_label = type_match.group(1).upper()
+            # Extract type from prefix (no legacy-positional fallback for
+            # address, matching the original parsing - only TEL had that)
+            type_label = extract_type_label(prefix, legacy_positional_fallback=False)
+            if type_label is not None:
+                address.type_label = type_label
 
         contact.addresses.append(address)
 

--- a/system/quickdeck/quickdeck.py
+++ b/system/quickdeck/quickdeck.py
@@ -439,6 +439,54 @@ class QuickDeckConfig:
             sg.popup_error(f"❌ Failed to save configuration: {e}", title="Error")
 
 
+def _emoji_font_paths() -> List[str]:
+    """Platform fallback list of TTF paths for rendering emoji glyphs."""
+    if os.name == 'nt':
+        return [
+            "C:/Windows/Fonts/seguiemj.ttf",  # Segoe UI Emoji
+            "C:/Windows/Fonts/segmdl2.ttf",  # Segoe MDL2 Assets
+        ]
+    return [
+        "/System/Library/Fonts/Apple Color Emoji.ttc",  # macOS
+        "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf",  # Linux
+    ]
+
+
+def _text_font_paths() -> List[str]:
+    """Platform fallback list of TTF paths for rendering button label text."""
+    if os.name == 'nt':
+        return [
+            "C:/Windows/Fonts/arial.ttf",
+            "C:/Windows/Fonts/calibri.ttf",
+        ]
+    return [
+        "/System/Library/Fonts/Arial.ttf",  # macOS
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",  # Linux
+    ]
+
+
+def _load_font(font_paths: List[str], size: int) -> ImageFont.FreeTypeFont:
+    """
+    Try each TTF path in order, returning the first that loads at `size`;
+    falls back to PIL's built-in default font if none are usable.
+
+    Consolidates the "pick a TTF from a platform fallback list, load with
+    ImageFont.truetype, fall through to load_default()" pattern previously
+    copy-pasted four times across QuickDeck (dedup: audit issue #64).
+    """
+    font = None
+    for font_path in font_paths:
+        if os.path.exists(font_path):
+            try:
+                font = ImageFont.truetype(font_path, size)
+                break
+            except OSError:
+                continue
+    if font is None:
+        font = ImageFont.load_default()
+    return font
+
+
 class QuickDeck:
     """Main QuickDeck application class."""
     
@@ -591,34 +639,10 @@ class QuickDeck:
             
             # Try to use a system emoji font
             try:
-                # Windows emoji font
-                if os.name == 'nt':
-                    font_paths = [
-                        "C:/Windows/Fonts/seguiemj.ttf",  # Segoe UI Emoji
-                        "C:/Windows/Fonts/segmdl2.ttf",  # Segoe MDL2 Assets
-                    ]
-                else:
-                    font_paths = [
-                        "/System/Library/Fonts/Apple Color Emoji.ttc",  # macOS
-                        "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf",  # Linux
-                    ]
-                
-                font = None
-                for font_path in font_paths:
-                    if os.path.exists(font_path):
-                        try:
-                            font = ImageFont.truetype(font_path, size)
-                            break
-                        except OSError:
-                            continue
-
-                if font is None:
-                    # Fallback to default font
-                    font = ImageFont.load_default()
-
+                font = _load_font(_emoji_font_paths(), size)
             except Exception:
                 font = ImageFont.load_default()
-            
+
             # Calculate text position to center the emoji with padding
             bbox = draw.textbbox((0, 0), emoji, font=font)
             text_width = bbox[2] - bbox[0]
@@ -662,28 +686,7 @@ class QuickDeck:
             
             # Calculate text width first to determine total width needed
             try:
-                if os.name == 'nt':
-                    font_paths = [
-                        "C:/Windows/Fonts/arial.ttf",
-                        "C:/Windows/Fonts/calibri.ttf",
-                    ]
-                else:
-                    font_paths = [
-                        "/System/Library/Fonts/Arial.ttf",  # macOS
-                        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",  # Linux
-                    ]
-                
-                font = None
-                for font_path in font_paths:
-                    if os.path.exists(font_path):
-                        try:
-                            font = ImageFont.truetype(font_path, text_size)
-                            break
-                        except OSError:
-                            continue
-
-                if font is None:
-                    font = ImageFont.load_default()
+                font = _load_font(_text_font_paths(), text_size)
 
                 # Calculate actual text width
                 temp_img = Image.new('RGBA', (1, 1), (0, 0, 0, 0))
@@ -716,33 +719,10 @@ class QuickDeck:
             
             # Add text below emoji
             try:
-                # Try to use a system font
-                if os.name == 'nt':
-                    font_paths = [
-                        "C:/Windows/Fonts/arial.ttf",
-                        "C:/Windows/Fonts/calibri.ttf",
-                    ]
-                else:
-                    font_paths = [
-                        "/System/Library/Fonts/Arial.ttf",  # macOS
-                        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",  # Linux
-                    ]
-                
-                font = None
-                for font_path in font_paths:
-                    if os.path.exists(font_path):
-                        try:
-                            font = ImageFont.truetype(font_path, text_size)
-                            break
-                        except OSError:
-                            continue
-
-                if font is None:
-                    font = ImageFont.load_default()
-
+                font = _load_font(_text_font_paths(), text_size)
             except Exception:
                 font = ImageFont.load_default()
-            
+
             # Calculate text position
             bbox = draw.textbbox((0, 0), text, font=font)
             text_width = bbox[2] - bbox[0]
@@ -818,22 +798,7 @@ class QuickDeck:
                     # Calculate proper image size based on text width
                     try:
                         # Calculate text width for proper sizing
-                        if os.name == 'nt':
-                            font_paths = ["C:/Windows/Fonts/arial.ttf", "C:/Windows/Fonts/calibri.ttf"]
-                        else:
-                            font_paths = ["/System/Library/Fonts/Arial.ttf", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"]
-                        
-                        font = None
-                        for font_path in font_paths:
-                            if os.path.exists(font_path):
-                                try:
-                                    font = ImageFont.truetype(font_path, text_size)
-                                    break
-                                except OSError:
-                                    continue
-
-                        if font is None:
-                            font = ImageFont.load_default()
+                        font = _load_font(_text_font_paths(), text_size)
 
                         temp_img = Image.new('RGBA', (1, 1), (0, 0, 0, 0))
                         temp_draw = ImageDraw.Draw(temp_img)

--- a/video/_ffmpeg_utils.py
+++ b/video/_ffmpeg_utils.py
@@ -1,0 +1,42 @@
+"""
+Shared FFmpeg / ffprobe helpers: GPU detection and video duration lookup.
+
+Consolidates check_gpu_available() and get_video_duration(), previously
+duplicated verbatim across video_reencoder.py and video_trim.py (dedup:
+audit issue #64). Uses the narrower, more precise exception list from
+video_trim.py's get_video_duration() (subprocess.CalledProcessError /
+FileNotFoundError / ValueError) rather than video_reencoder.py's bare
+`except Exception`, so an unexpected bug surfaces instead of being
+silently swallowed as "no duration".
+"""
+
+import subprocess
+from typing import Optional
+
+
+def check_gpu_available() -> bool:
+    """Return True if an NVIDIA GPU with NVENC support is available for ffmpeg."""
+    try:
+        result = subprocess.run(["nvidia-smi"], capture_output=True, text=True)
+        if result.returncode != 0:
+            return False
+        encoders_check = subprocess.run(["ffmpeg", "-encoders"], capture_output=True, text=True)
+        return "h264_nvenc" in encoders_check.stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def get_video_duration(input_path: str) -> Optional[float]:
+    """Get video duration in seconds using ffprobe. Returns float or None on error."""
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error", "-show_entries",
+                "format=duration", "-of",
+                "default=noprint_wrappers=1:nokey=1", input_path
+            ],
+            capture_output=True, text=True, check=True, timeout=30
+        )
+        return float(result.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+        return None

--- a/video/video_reencoder.py
+++ b/video/video_reencoder.py
@@ -10,16 +10,7 @@ import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
-
-def check_gpu_available():
-    try:
-        result = subprocess.run(["nvidia-smi"], capture_output=True, text=True)
-        if result.returncode != 0:
-            return False
-        enc = subprocess.run(["ffmpeg", "-encoders"], capture_output=True, text=True)
-        return "h264_nvenc" in enc.stdout
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
+from _ffmpeg_utils import check_gpu_available, get_video_duration
 
 
 def get_file_info(file_path):
@@ -27,21 +18,6 @@ def get_file_info(file_path):
     size_mb = size_bytes / (1024 * 1024)
     ext = os.path.splitext(file_path)[1].lower().replace(".", "")
     return ext, size_mb
-
-
-def get_video_duration(input_path):
-    try:
-        result = subprocess.run(
-            [
-                "ffprobe", "-v", "error", "-show_entries",
-                "format=duration", "-of",
-                "default=noprint_wrappers=1:nokey=1", input_path
-            ],
-            capture_output=True, text=True, check=True, timeout=30
-        )
-        return float(result.stdout.strip())
-    except Exception:
-        return None
 
 
 def reencode_video(

--- a/video/video_trim.py
+++ b/video/video_trim.py
@@ -13,6 +13,8 @@ import threading
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
+from _ffmpeg_utils import check_gpu_available, get_video_duration
+
 log = logging.getLogger(__name__)
 
 # -------------------------------------------------------
@@ -60,38 +62,8 @@ def seconds_to_time_str(seconds, with_fraction=True):
 
 
 # -------------------------------------------------------
-# FFprobe: get video duration
+# FFprobe / GPU check: see _ffmpeg_utils.py (shared with video_reencoder.py)
 # -------------------------------------------------------
-
-def get_video_duration(input_path):
-    """Get video duration in seconds using ffprobe. Returns float or None on error."""
-    try:
-        result = subprocess.run(
-            [
-                "ffprobe", "-v", "error", "-show_entries",
-                "format=duration", "-of",
-                "default=noprint_wrappers=1:nokey=1", input_path
-            ],
-            capture_output=True, text=True, check=True, timeout=30
-        )
-        return float(result.stdout.strip())
-    except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
-        return None
-
-
-# -------------------------------------------------------
-# GPU check
-# -------------------------------------------------------
-
-def check_gpu_available():
-    try:
-        result = subprocess.run(["nvidia-smi"], capture_output=True, text=True)
-        if result.returncode != 0:
-            return False
-        encoders_check = subprocess.run(["ffmpeg", "-encoders"], capture_output=True, text=True)
-        return "h264_nvenc" in encoders_check.stdout
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
 
 
 # -------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves 11 of the 13 duplication findings in #64 by extracting shared helpers per subtree:

- **Notion** — consolidated the paginated `databases.query` loop and property-value extraction into `notion/utils.py`, used by `build_newsletter.py`, `journal_automation.py`, `normalize_names.py`, `normalize_url.py`, and `sample_illustrations.py`. Also unified `normalize_names.py`/`normalize_url.py`'s near-identical credential/config helpers.
- **Google** — extracted the OAuth token load/refresh/save dance + config loading into new `google/_auth.py`, shared by `gmail_drive_automation.py` and `weekly_photo_automation.py`.
- **Image** — unified `image_resizer.py`'s two near-identical resize functions behind a `preserve_dimensions` flag; extracted `illustrations_formatter.py`'s shared folder-processing scaffolding into `_process_folder_common`; merged the HEIC/PNG converters into shared `image/_image_to_jpg_converter.py`; deduped `photos_archive.py`'s exclusion/copy prompt flow; shared `illustrations_formatter.py`'s `CONFIG_FILE` constant/defaults with its GUI.
- **Video** — extracted `check_gpu_available`/`get_video_duration` into `video/_ffmpeg_utils.py`, shared by `video_reencoder.py` and `video_trim.py`.
- **System** — extracted `quickdeck.py`'s four-times-copied font-fallback loader into a single `_load_font` helper; consolidated vCard TEL/EMAIL/ADR `TYPE=` parsing into `system/apple/_vcard_fields.py`, shared by `unify_vcards.py` and `convert_to_apple.py`.
- **Audio** — removed `audio_extractor_core.py`'s ad-hoc GUI code path; `--gui` now routes to the real `audio_extractor_gui.py` module instead of a thinner duplicate.

### Behavior change (flagged explicitly)

`convert_to_apple.py`'s `TYPE=` parsing was provably buggy for the legacy single-semicolon shape (e.g. `TEL;HOME:+123`): it split the *whole raw line* on `;` before isolating the value, so the value leaked into the extracted type or the reconstructed output line. The new shared `_vcard_fields.extract_type_label()` isolates the prefix (everything before the first `:`) first, matching `unify_vcards.py`'s already-correct regex-based approach. Verified via before/after traces on representative legacy TEL/EMAIL/ADR lines — old code mis-parsed them, new code parses them correctly.

### Known remaining items (not bugs, deliberately deferred)

Two of the 13 findings are intentionally left open:
- **`notion/articles_sync/notion_articles_sync.py`** pagination/property-extraction dedup — left alone because that logic is fused with its own rate-limiter and is protected by existing regression tests guarding a previously-fixed sync bug; touching it safely is a separate, more careful pass.
- **`google/test_all_scopes.py`** auth dedup — that file no longer exists in the form the issue described (only a stale `.pyc` remains on disk), so there's nothing left to dedupe there.

## Validation

- `python -m py_compile` on all 24 touched/added files — clean.
- No test suite or `.github/workflows/` declared in this repo's `CLAUDE.md` (script grab-bag repo) — no CI to await.
- Diff reviewed against each of the 11 checked-off findings in #64; nothing outside stated scope.

Closes #64
