### PR TITLE
docs: add hand-authored internal architecture diagram

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,7 @@ Canonical instructions for AI coding agents working in this repository. Claude C
 ## This repository
 Personal automation monorepo: independent Python scripts and small tools across multiple domains (audio, video, image, google, notion, linkedin, system, etc.) on Windows + PowerShell.
 See `README.md` for setup, layout, and usage.
+
+## Internal architecture
+
+[`docs/architecture.mmd`](docs/architecture.mmd) is a hand-authored Mermaid diagram of this repo's own internal structure (the domain folders, shared per-domain helpers like `google/_auth.py` and `notion/utils.py`, and the external services each domain talks to). Update it in the same PR as any material structural change (a new domain folder, a shared helper added/moved, a script relocated) — same anti-staleness contract as this repo's `.fleet.toml` `description` field. It is not auto-generated and not covered by any test suite.

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -1,0 +1,72 @@
+%% docs/architecture.mmd — this repo's own internal structure.
+%% Hand-authored, not generated — this is a flat grab-bag of independent
+%% Python tools grouped by domain folder, not a single coupled system, so
+%% there is no crawl-and-render pipeline the way fleet-config's system-map
+%% works. Update this diagram in the same PR as any material structural
+%% change (a new domain folder, a shared helper introduced/moved, a script
+%% relocated) — same anti-staleness contract as a `.fleet.toml` `description`
+%% field. See fleet-config's global-CLAUDE.md "Every repo carries a
+%% `.fleet.toml`" section for the general convention.
+
+flowchart TB
+  ENV[".env / .env.sample\nroot secrets + shared config (API keys, folder paths)"]
+  REQ["requirements.txt\nshared Python deps, source-commented per script"]
+  VENVMGR["system/venv_manager.py\ncreates/monitors the shared .venv"]
+  REQ --> VENVMGR
+
+  subgraph domains["Domain folders — mostly independent scripts, each usually paired\nwith a .bat launcher, a per-script .md doc, and/or a JSON config"]
+    AUDIO["audio/\naudio_extractor_core/gui · audio_normalize · audio_trim ·\nconvert_ogg_mp3 · transcript_collate"]
+    IMAGE["image/\nillustrations_formatter(_gui) · photos_archive · image_resizer ·\ncarrousel_pdf_to_jpg · pdf_to_jpg/ · screenshot · imgur_check_rate"]
+    VIDEO["video/\nscreen_recorder · video_download · video_reencoder ·\nvideo_trim/concatenator · gpu_recovery"]
+    TEXT["text/\nconvert_pdf_to_txt · clean_sensitive_data"]
+    EXCEL["excel/\naccounting_stripe/"]
+    HTML["html/\ncountdown_timer.html"]
+    SMARTLIFE["smart_life/\ndevice automation (despacho_switch.bat, devices.sample.json)"]
+    SYSTEM["system/\nkeycaster · quickdeck/ · textexpander/ · wifi/ ·\nmarkdown_preview · mouse_mover · apple/"]
+  end
+  ENV --> domains
+  VENVMGR -.->|shared runtime for| domains
+
+  subgraph googlebox["google/"]
+    GAUTH["_auth.py\nshared OAuth token/config loader"]
+    GMAIL["gmail_drive_automation.py"]
+    GPHOTOS["weekly_photo_automation.py"]
+    GDIAG["setup_helper_script.py · diag_all_scopes.py · diag_gmail_drive.py"]
+  end
+  GAUTH --> GMAIL
+  GAUTH --> GPHOTOS
+  ENV --> GAUTH
+  GMAIL --> GAPIS["Gmail / Drive APIs"]
+  GPHOTOS --> GAPIS
+
+  subgraph notionbox["notion/"]
+    NUTILS["utils.py\nshared Notion client + legacy notion-params helper"]
+    NBUILD["build_newsletter.py"]
+    NDB["notion_databases_dump/query/clean/\nadd_editorial/editorial.py"]
+    NSYNC["notion_excel_sync.py · articles_sync/"]
+    NCLEAN["normalize_names.py · normalize_url.py ·\ntodoist_migration.py · journal_automation.py"]
+  end
+  NUTILS --> NBUILD
+  NUTILS --> NDB
+  NUTILS --> NSYNC
+  NUTILS --> NCLEAN
+  ENV --> NUTILS
+  NBUILD --> NOTIONAPI["Notion API"]
+  NDB --> NOTIONAPI
+  NSYNC --> NOTIONAPI
+
+  subgraph linkedinbox["linkedin/"]
+    CHECKIP["check_ip/\nreverse-image search (config.py holds Imgur + SerpAPI keys)"]
+    OPENPROF["open_profiles/\nExcel-driven profile/company page opener"]
+    PROFEXTRACT["profiles_data_extractor/\nDevTools extraction + common/dashboard.py\n(Streamlit + Plotly dashboard) + Excel formatting"]
+  end
+  ENV --> CHECKIP
+  CHECKIP --> IMGUR["Imgur API"]
+  CHECKIP --> SERPAPI["SerpAPI (Google Lens)"]
+
+  EXTBIN["External binaries\nFFmpeg (audio/video) · Poppler (pdf_to_jpg) ·\nWhisper model (transcription)"]
+  AUDIO --> EXTBIN
+  VIDEO --> EXTBIN
+  IMAGE --> EXTBIN
+
+  DOCS["CLAUDE.md / AGENTS.md / README.md\nagent instructions + module catalog"]


### PR DESCRIPTION
## Summary
- Adds `docs/architecture.mmd` — a hand-authored Mermaid flowchart of this repo's own internal structure: the domain folders (audio, image, video, text, excel, html, smart_life, system, google, notion, linkedin), the shared per-domain helpers (`google/_auth.py`, `notion/utils.py`), and the external services each domain talks to (Gmail/Drive APIs, Notion API, Imgur, SerpAPI, FFmpeg/Poppler/Whisper).
- Adds an "Internal architecture" section to `CLAUDE.md` pointing at the diagram, with the anti-staleness contract (update it in the same PR as any material structural change).
- Companion to the fleet-wide convention introduced in `ferraroroberto/fleet-config#256` (already merged); this is this repo's counterpart to fleet-config's own `docs/architecture.mmd`.

## Validation
This repo has no declared verification gate — no `Verification` section in `CLAUDE.md`, no `tests/` directory, no CI workflow, no `verify-before-ship` script. Ran what applies to a docs-only change:
- Mermaid syntax gate: rendered `docs/architecture.mmd` twice via `npx @mermaid-js/mermaid-cli` (`mmdc`) to SVG with no errors.
- Cross-checked every domain folder named in the diagram against the actual repo layout (`ls`) — all 11 exist and match.
- Verified shared helpers named in the diagram (`google/_auth.py`, `notion/utils.py`) and external-service references (Imgur/SerpAPI keys in `linkedin/check_ip/config.py`) actually exist in the code.
- `git diff main...HEAD` reviewed — scoped to exactly the new `docs/architecture.mmd` file and the one CLAUDE.md addition, no unintended changes.

## Test plan
- [x] `docs/architecture.mmd` exists and is valid Mermaid (rendered clean via mermaid-cli).
- [x] `CLAUDE.md` references it, with the anti-staleness line.

Closes #76