### PR TITLE
feat: add HWiNFO64 restart script for scheduled unattended use

### DIFF
--- a/system/README.md
+++ b/system/README.md
@@ -63,6 +63,14 @@ Lists the files directly inside a chosen folder (top level only, not recursive) 
 - **How to run:** `python system/list_files_to_xls.py` — no command-line arguments. It always opens a Tkinter folder-picker dialog first; there is no way to pass the folder as an argument. On completion it shows a message box confirming the save path and file count.
 - **Requirements:** `openpyxl`, `tkinter`.
 
+## 🌡️ hwinfo_restart.py
+
+Restarts HWiNFO64 (a system monitoring app that stops reporting after a continuous 12-hour run) — terminates it if running, then relaunches it from its install path. Intended to be run on a recurring schedule (e.g. every 8 hours) by an external scheduler; the script itself does a single restart cycle per invocation with no internal loop or sleep.
+
+- **How to run:** `python system/hwinfo_restart.py` — no command-line arguments. Looks for the install path at `C:\Program Files\HWiNFO64\HWiNFO64.exe`, falling back to the `(x86)` variant; raises `FileNotFoundError` if neither exists.
+- **Launcher:** `hwinfo_restart.bat` calls `python hwinfo_restart.py` — no args needed.
+- **Requirements:** `psutil`. Windows only.
+
 ## Already documented
 
 These `system/` tools have their own dedicated doc file — see there instead of here:

--- a/system/hwinfo_restart.bat
+++ b/system/hwinfo_restart.bat
@@ -1,0 +1,2 @@
+@echo off
+python "%~dp0hwinfo_restart.py"

--- a/system/hwinfo_restart.py
+++ b/system/hwinfo_restart.py
@@ -1,0 +1,78 @@
+import logging
+import os
+import subprocess
+import sys
+import time
+
+import psutil
+
+log = logging.getLogger(__name__)
+
+PROCESS_NAME = "HWiNFO64.exe"
+INSTALL_PATHS = [
+    r"C:\Program Files\HWiNFO64\HWiNFO64.exe",
+    r"C:\Program Files (x86)\HWiNFO64\HWiNFO64.exe",
+]
+
+
+def find_install_path() -> str:
+    for path in INSTALL_PATHS:
+        if os.path.isfile(path):
+            return path
+    raise FileNotFoundError(f"{PROCESS_NAME} not found in any of: {INSTALL_PATHS}")
+
+
+def _matching_procs():
+    return [
+        proc
+        for proc in psutil.process_iter(["name"])
+        if (proc.info["name"] or "").lower() == PROCESS_NAME.lower()
+    ]
+
+
+def stop_running() -> None:
+    # HWiNFO64 runs elevated for sensor/driver access, so from a non-elevated
+    # process psutil can send TerminateProcess but cannot open a handle to
+    # wait() or kill() it (AccessDenied) — poll process_iter instead.
+    procs = _matching_procs()
+    if not procs:
+        log.info("%s was not running", PROCESS_NAME)
+        return
+    for proc in procs:
+        log.info("Terminating %s (pid %d)", PROCESS_NAME, proc.pid)
+        try:
+            proc.terminate()
+        except psutil.Error:
+            log.warning("Could not signal %s (pid %d)", PROCESS_NAME, proc.pid, exc_info=True)
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and _matching_procs():
+        time.sleep(0.5)
+
+    for proc in _matching_procs():
+        log.warning("%s (pid %d) did not exit gracefully, killing", PROCESS_NAME, proc.pid)
+        try:
+            proc.kill()
+        except psutil.Error:
+            log.warning("Could not kill %s (pid %d)", PROCESS_NAME, proc.pid, exc_info=True)
+
+
+def restart() -> None:
+    stop_running()
+    install_path = find_install_path()
+    log.info("Launching %s", install_path)
+    subprocess.Popen([install_path], close_fds=True)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    try:
+        restart()
+    except Exception:
+        log.exception("Failed to restart %s", PROCESS_NAME)
+        sys.exit(1)
+    log.info("%s restart complete", PROCESS_NAME)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- \`system/hwinfo_restart.py\`: terminates HWiNFO64.exe if running, then relaunches it from its install path. Single restart cycle per invocation, no internal loop/sleep — an external scheduler (app-launcher's Jobs tab, \`ferraroroberto/app-launcher#350\`) drives the 8-hourly cadence.
- \`system/hwinfo_restart.bat\` launcher + \`system/README.md\` entry, matching the sibling-script house style.

## Discovered during validation
HWiNFO64 runs elevated (its manifest requires admin for hardware sensor access). From a non-elevated caller, \`psutil\` can send \`terminate()\` but not \`wait()\`/\`kill()\` (AccessDenied opening the process handle) — the script now polls \`process_iter\` for exit instead of \`psutil.wait_procs\`, and swallows \`psutil.Error\` on the terminate/kill calls so it degrades to a warning instead of crashing. Relaunching an elevated exe from a non-elevated parent also fails (\`Start-Process\`/\`subprocess.Popen\` get "the operation was canceled by the user" — a blocked UAC prompt), which is why the actual scheduled invocation needs to run elevated; that's what \`app-launcher#350\` (merged) adds support for on the scheduling side.

## Validation
- \`py_compile\` — clean
- Real-world test against the live HWiNFO64 process (pid 54432): confirmed \`terminate()\` works even non-elevated; confirmed the original \`wait_procs\`-based version crashed on \`AccessDenied\`, fixed to poll instead; confirmed relaunch requires elevation (documented above) — the fixed script's terminate/poll path was re-verified to not crash non-elevated; full elevated end-to-end (terminate + relaunch) will be proven once the real Task Scheduler entry is registered on \`app-launcher\`'s side with \`elevated: true\`

## Test plan
- [x] \`py_compile\` passes on the new script
- [x] Manually ran against the real HWiNFO64.exe process — confirmed clean termination; confirmed non-elevated relaunch is blocked (expected — elevation is handled at the scheduler level)
- [x] \`system/README.md\` updated with the new entry

Closes #78