### PR TITLE
fix: use os.startfile instead of subprocess.Popen for HWiNFO64 relaunch

### DIFF
--- a/system/hwinfo_restart.py
+++ b/system/hwinfo_restart.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import subprocess
 import sys
 import time
 
@@ -61,7 +60,13 @@ def restart() -> None:
     stop_running()
     install_path = find_install_path()
     log.info("Launching %s", install_path)
-    subprocess.Popen([install_path], close_fds=True)
+    # HWiNFO64.exe's requireAdministrator manifest only gets honored through
+    # ShellExecute-style launches (os.startfile) — subprocess.Popen's plain
+    # CreateProcess raises WinError 740 (elevation required) even from an
+    # already-elevated caller (empirically verified: IsUserAnAdmin()==1 in
+    # the calling process, subprocess.Popen still fails regardless of
+    # close_fds, while os.startfile succeeds).
+    os.startfile(install_path, cwd=os.path.dirname(install_path))
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- `restart()` now calls `os.startfile(install_path, cwd=...)` instead of `subprocess.Popen([install_path], close_fds=True)`.
- Root cause (isolated via a live series of tests on the actual machine): HWiNFO64.exe's `requireAdministrator` manifest is only honored by `ShellExecute`-style launches — `subprocess.Popen`'s plain `CreateProcess` unconditionally raises `WinError 740` (elevation required) for this target, **even from an already-elevated caller** (confirmed `ctypes.windll.shell32.IsUserAnAdmin() == 1` in the calling process; reproduced independent of `close_fds`).

## Validation
- `py_compile` — clean
- Real end-to-end test via the actual `\AppLauncher\hwinfo-restart` Task Scheduler entry (`elevated: true`, `RunLevel: HighestAvailable`, interactive-token logon):
  - Fire #1 (HWiNFO64 not running): `HWiNFO64.exe restart complete`, `status: success`, `exit_code: 0`
  - Fire #2 (HWiNFO64 already running, pid 43596): terminated cleanly and relaunched as a new pid (68016) — confirms the full terminate+relaunch cycle, not just launch-from-stopped

(Also tried an S4U logon variant along the way to work around what looked like an elevation issue — that hit a different error, `WinError 1459: interactive window station required`, since `os.startfile`/`ShellExecute` needs a desktop session that S4U logons don't have. Reverted to the original interactive-token + `RunLevel HighestAvailable` config, which works correctly once the script no longer uses `subprocess.Popen`.)

## Test plan
- [x] `py_compile` passes
- [x] Real elevated scheduled-task fire launches HWiNFO64 successfully (no traceback, process appears)
- [x] Full terminate + relaunch cycle verified (pid changes across two consecutive fires)

Closes #80